### PR TITLE
Support for reading multiple objects on the input stream which are not wrapped in a container

### DIFF
--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -5,7 +5,7 @@ from nose import main
 from nose.tools import *
 from nose.plugins.skip import SkipTest
 
-from msgpack import packs, unpacks, Packer, Unpacker
+from msgpack import pack, packs, unpack, unpacks, Packer, Unpacker
 
 from StringIO import StringIO
 
@@ -56,6 +56,22 @@ def testPackBytes():
         ]
     for td in test_data:
         check(td)
+
+def testPackNonSequenceObjects():
+    test_objs = [1, 3.14, "Hello", [0, 1, 2], {'one': 1, 'two': 2}]
+    out = StringIO()
+    for obj in test_objs:
+        pack(obj, out)
+    out.seek(0)
+    out_objs = []
+    while 1:
+        obj = unpack(out, use_list=True)
+        if obj is None:
+            break
+        out_objs.append(obj)
+    assert_equal(len(test_objs), len(out_objs))
+    for a, b in zip(test_objs, out_objs):
+        assert_equal(a, b)
 
 def testIgnoreUnicodeErrors():
     re = unpacks(packs('abc\xeddef'),


### PR DESCRIPTION
The current API does not allow you to read in streamed serialised objects from a file which are not wrapped in some overall container (Array or Map). This was due to "unpack" not being able to use the "ret" value in "unpackb" to reseek the input stream.

I've added support for this and an appropriate test case. Having never written Pyrex code before though, it might need some tweaking for memory leaks etc :)
