### PR TITLE
Pyrex will fail is trying to set a inherited object from dict. 

### DIFF
--- a/msgpack/_msgpack.pyx
+++ b/msgpack/_msgpack.pyx
@@ -127,7 +127,7 @@ cdef class Packer(object):
             ret = msgpack_pack_raw(&self.pk, len(o))
             if ret == 0:
                 ret = msgpack_pack_raw_body(&self.pk, rawval, len(o))
-        elif PyDict_Check(o):
+        elif PyDict_CheckExact(o):
             d = o
             ret = msgpack_pack_map(&self.pk, len(d))
             if ret == 0:


### PR DESCRIPTION
Suppose we have:

```
class MyDict(dict):
    pass

msgpack.dumps(MyDict())
```

It will fail with:

```
  File "_msgpack.pyx", line 172, in msgpack._msgpack.packb (msgpack/_msgpack.c:2377)
  File "_msgpack.pyx", line 154, in msgpack._msgpack.Packer.pack (msgpack/_msgpack.c:2013)
  File "_msgpack.pyx", line 131, in msgpack._msgpack.Packer._pack (msgpack/_msgpack.c:1603)
TypeError: Expected dict, got MyDict
```
