### PR TITLE
Make sure objects inherited from Dict are properly casted

### DIFF
--- a/msgpack/_msgpack.pyx
+++ b/msgpack/_msgpack.pyx
@@ -128,7 +128,7 @@ cdef class Packer(object):
             if ret == 0:
                 ret = msgpack_pack_raw_body(&self.pk, rawval, len(o))
         elif PyDict_Check(o):
-            d = o
+            d = <dict>o
             ret = msgpack_pack_map(&self.pk, len(d))
             if ret == 0:
                 for k,v in d.iteritems():


### PR DESCRIPTION
Cython will complain and crash if not:

```
  File "_msgpack.pyx", line 173, in msgpack._msgpack.packb (msgpack/_msgpack.c:2400)
  File "_msgpack.pyx", line 153, in msgpack._msgpack.Packer.pack (msgpack/_msgpack.c:2089)
  File "_msgpack.pyx", line 155, in msgpack._msgpack.Packer.pack (msgpack/_msgpack.c:1997)
  File "_msgpack.pyx", line 138, in msgpack._msgpack.Packer._pack (msgpack/_msgpack.c:1710)
  File "_msgpack.pyx", line 144, in msgpack._msgpack.Packer._pack (msgpack/_msgpack.c:1817)
  File "_msgpack.pyx", line 132, in msgpack._msgpack.Packer._pack (msgpack/_msgpack.c:1624)
TypeError: {'exc_message': 'Expected dict, got MyDict', 'exc_type': 'TypeError'}
```
