### PR TITLE
Note that msgpack.unpack(s) reads s to EOF

### DIFF
--- a/msgpack/_msgpack.pyx
+++ b/msgpack/_msgpack.pyx
@@ -258,7 +258,7 @@ def unpack(object stream, object object_hook=None, object list_hook=None,
            bint use_list=0, encoding=None, unicode_errors="strict",
            ):
     """
-    unpack an object from stream.
+    unpack an object from stream. discards any content remaining on the stream after the unpacked object.
     """
     return unpackb(stream.read(), use_list=use_list,
                    object_hook=object_hook, list_hook=list_hook,


### PR DESCRIPTION
The side-effects of this function call should be clearer.
