### PR TITLE
Allow packed data to be captured while executing skip(), etc.

### DIFF
--- a/test/test_unpack_raw.py
+++ b/test/test_unpack_raw.py
@@ -1,0 +1,32 @@
+"""Tests for cases where the user seeks to obtain packed msgpack objects"""
+
+from nose import main
+from nose.tools import *
+import six
+from msgpack import Unpacker, packb
+
+def test_write_bytes():
+    unpacker = Unpacker()
+    unpacker.feed(b'abc')
+    f = six.BytesIO()
+    assert_equal(unpacker.unpack(f.write), ord('a'))
+    assert_equal(f.getvalue(), b'a')
+    f.truncate(0)
+    assert_is_none(unpacker.skip(f.write))
+    assert_equal(f.getvalue(), b'b')
+    f.truncate(0)
+    assert_is_none(unpacker.skip())
+    assert_equal(f.getvalue(), b'')
+
+def test_write_bytes_multi_buffer():
+    long_val = (5) * 100
+    expected = packb(long_val)
+    unpacker = Unpacker(six.BytesIO(expected), read_size=3, max_buffer_size=3)
+
+    f = six.BytesIO()
+    unpacked = unpacker.unpack(f.write)
+    assert_equal(unpacked, long_val)
+    assert_equal(f.getvalue(), expected)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
One may want to acquire the bytes corresponding to a single msgpack message. For example, consider a server whose job is to forward messages to a set of workers.

In the first instance, it may not care what the messages contain, it just reads messages off a stream and passes them on to workers. With the current `msgpack-python`, if the message length is not known, this requires unpacking and re-packing. Ideally one might want `Unpacker.read_packed()`. This patch instead offers the idiom:

```
bio = BytesIO()
unpacker.skip(bio.write)
msg_bytes = bio.getvalue()
```

Now consider the case that our server still passes on raw messages, but only those who have a particular value, say `route_to == 'me'`:

```
bio = BytesIO()
obj = unpacker.unpack(bio.write)
if obj['route_to'] is 'me':
  route_to_me(bio.getvalue())
```

This avoids packing. With `read_map_header` supporting a similar interface, the following does the same, but avoids full unpacking:

```
bio = BytesIO()
route_to = None
map_size = unpacker.read_map_header(bio.write)
for i in range(map_size):
  key = unpacker.unpack(bio.write)
  if key is 'route_to':
    route_to = unpacker.unpack(bio.write)
  else:
    unpacker.skip(bio.write)
if route_to is 'me':
  route_to_me(bio.getvalue())
```
