### PR TITLE
Object pairs hook

### DIFF
--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -22,6 +22,7 @@
 typedef struct unpack_user {
     int use_list;
     PyObject *object_hook;
+    bool has_pairs_hook;
     PyObject *list_hook;
     const char *encoding;
     const char *unicode_errors;
@@ -160,9 +161,7 @@ static inline int template_callback_array_item(unpack_user* u, unsigned int curr
 static inline int template_callback_array_end(unpack_user* u, msgpack_unpack_object* c)
 {
     if (u->list_hook) {
-        PyObject *arglist = Py_BuildValue("(O)", *c);
-        PyObject *new_c = PyEval_CallObject(u->list_hook, arglist);
-        Py_DECREF(arglist);
+        PyObject *new_c = PyEval_CallFunction(u->list_hook, "(O)", *c);
         Py_DECREF(*c);
         *c = new_c;
     }
@@ -171,16 +170,31 @@ static inline int template_callback_array_end(unpack_user* u, msgpack_unpack_obj
 
 static inline int template_callback_map(unpack_user* u, unsigned int n, msgpack_unpack_object* o)
 {
-    PyObject *p = PyDict_New();
+    PyObject *p;
+    if (u->has_pairs_hook) {
+        p = PyList_New(n); // Or use tuple?
+    }
+    else {
+        p = PyDict_New();
+    }
     if (!p)
         return -1;
     *o = p;
     return 0;
 }
 
-static inline int template_callback_map_item(unpack_user* u, msgpack_unpack_object* c, msgpack_unpack_object k, msgpack_unpack_object v)
+static inline int template_callback_map_item(unpack_user* u, unsigned int current, msgpack_unpack_object* c, msgpack_unpack_object k, msgpack_unpack_object v)
 {
-    if (PyDict_SetItem(*c, k, v) == 0) {
+    if (u->has_pairs_hook) {
+        msgpack_unpack_object item = PyTuple_Pack(2, k, v);
+        if (!item)
+            return -1;
+        Py_DECREF(k);
+        Py_DECREF(v);
+        PyList_SET_ITEM(*c, current, item);
+        return 0;
+    }
+    else if (PyDict_SetItem(*c, k, v) == 0) {
         Py_DECREF(k);
         Py_DECREF(v);
         return 0;
@@ -191,9 +205,7 @@ static inline int template_callback_map_item(unpack_user* u, msgpack_unpack_obje
 static inline int template_callback_map_end(unpack_user* u, msgpack_unpack_object* c)
 {
     if (u->object_hook) {
-        PyObject *arglist = Py_BuildValue("(O)", *c);
-        PyObject *new_c = PyEval_CallObject(u->object_hook, arglist);
-        Py_DECREF(arglist);
+        PyObject *new_c = PyEval_CallFunction(u->object_hook, "(O)", *c);
         Py_DECREF(*c);
         *c = new_c;
     }

--- a/msgpack/unpack_template.h
+++ b/msgpack/unpack_template.h
@@ -357,7 +357,7 @@ _push:
 		c->ct = CT_MAP_VALUE;
 		goto _header_again;
 	case CT_MAP_VALUE:
-		if(construct_cb(_map_item)(user, &c->obj, c->map_key, obj) < 0) { goto _failed; }
+		if(construct_cb(_map_item)(user, c->count, &c->obj, c->map_key, obj) < 0) { goto _failed; }
 		if(++c->count == c->size) {
 			obj = c->obj;
 			construct_cb(_map_end)(user, &obj);

--- a/test/test_obj.py
+++ b/test/test_obj.py
@@ -26,6 +26,16 @@ def test_decode_hook():
     unpacked = unpackb(packed, object_hook=_decode_complex)
     eq_(unpacked[1], 1+2j)
 
+def test_decode_pairs_hook():
+    packed = packb([3, {1: 2, 3: 4}])
+    prod_sum = 1 * 2 + 3 * 4
+    unpacked = unpackb(packed, object_pairs_hook=lambda l: sum(k * v for k, v in l))
+    eq_(unpacked[1], prod_sum)
+
+@raises(ValueError)
+def test_only_one_obj_hook():
+    unpackb('', object_hook=lambda x: x, object_pairs_hook=lambda x: x)
+
 @raises(ValueError)
 def test_bad_hook():
     packed = packb([3, 1+2j], default=lambda o: o)

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -111,10 +111,9 @@ def test_odict():
     seq = [(b'one', 1), (b'two', 2), (b'three', 3), (b'four', 4)]
     od = odict(seq)
     assert_equal(unpackb(packb(od)), dict(seq))
-    # After object_pairs_hook is implemented.
-    #def pair_hook(seq):
-    #    return seq
-    #assert_equal(unpackb(packb(od), object_pairs_hook=pair_hook), seq)
+    def pair_hook(seq):
+        return seq
+    assert_equal(unpackb(packb(od), object_pairs_hook=pair_hook), seq)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As per issue #19. Implemented such that `object_pairs_hook` gets stored in `user.object_hook` with an additional `user.has_pairs_hook` flag. At the same time I have factored out the `ctx[.user]` initialisation in common between `unpackb` and `Unpacker`.
