### PR TITLE
Fix Unpacker example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,15 +52,15 @@ stream.
 
    buf.seek(0)
 
-    unpacker = msgpack.Unpacker()
-    while True:
+   unpacker = msgpack.Unpacker()
+   while True:
        data = buf.read(16)
        if not data:
            break
        unpacker.feed(data)
 
-    for unpacked in unpacker:
-       print unpacked
+       for unpacked in unpacker:
+           print unpacked
 
 packing/unpacking of custom data type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The Unpacker example in the README did not work properly, since it was dropping bytes.
