### PR TITLE
Give python access to the internal buffer of Packer

### DIFF
--- a/msgpack/buff_converter.h
+++ b/msgpack/buff_converter.h
@@ -1,0 +1,28 @@
+#include "Python.h"
+
+/* cython does not support this preprocessor check => write it in raw C */
+#if PY_MAJOR_VERSION == 2
+static PyObject *
+buff_to_buff(char *buff, Py_ssize_t size)
+{
+    return PyBuffer_FromMemory(buff, size);
+}
+
+#elif (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION >= 3)
+static PyObject *
+buff_to_buff(char *buff, Py_ssize_t size)
+{
+    return PyMemoryView_FromMemory(buff, size, PyBUF_READ);
+}
+#else
+static PyObject *
+buff_to_buff(char *buff, Py_ssize_t size)
+{
+    Py_buffer pybuf;
+    if (PyBuffer_FillInfo(&pybuf, NULL, buff, size, 1, PyBUF_FULL_RO) == -1) {
+        return NULL;
+    }
+
+    return PyMemoryView_FromBuffer(&pybuf);
+}
+#endif


### PR DESCRIPTION
Hi, this pull request is a slightly performance improvement to the packer.
This patch adds a API to access the internal buffer of the packer by converting it to a buffer/memoryview object. 

This buffer/memoryview can be passed to the typical functions, like
socket.send, socket.sendall, file.write, ....
These functions access then directly the char\* buffer from the Packer.
This approach avoids the memory allocation and memory copy done in PyBytes_FromStringAndSize also known as 'Zero-copy'

Important note: used incorrectly it possible to produce segfaults.
For example this code will segfault

``` python
from msgpack import Packer
Packer().pack(range(100), ret_as_buff=1)[100]
```

because the packer is deallocated but the returned buffer points still to the internal memory. 
