### PR TITLE
Read and pack raw header

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -221,6 +221,17 @@ cdef class Packer(object):
             self.pk.length = 0
             return buf
 
+    def pack_raw_header(self, size_t size):
+        cdef int ret = msgpack_pack_raw(&self.pk, size)
+        if ret == -1:
+            raise MemoryError
+        elif ret:  # should not happen
+            raise TypeError
+        if self.autoreset:
+            buf = PyBytes_FromStringAndSize(self.pk.buf, self.pk.length)
+            self.pk.length = 0
+            return buf
+
     def pack_map_pairs(self, object pairs):
         """
         Pack *pairs* as msgpack map type.

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -43,6 +43,7 @@ cdef extern from "unpack.h":
     execute_fn unpack_skip
     execute_fn read_array_header
     execute_fn read_map_header
+    execute_fn read_raw_header
     void unpack_init(unpack_context* ctx)
     object unpack_data(unpack_context* ctx)
 
@@ -374,7 +375,8 @@ cdef class Unpacker(object):
         """assuming the next object is an array, return its size n, such that
         the next n unpack() calls will iterate over its contents.
 
-        Raises `OutOfData` when there are no more bytes to unpack.
+        Raises `OutOfData` when there are no more bytes to unpack, and
+        ValueError if the next object is not an array.
         """
         return self._unpack(read_array_header, write_bytes)
 
@@ -382,9 +384,19 @@ cdef class Unpacker(object):
         """assuming the next object is a map, return its size n, such that the
         next n * 2 unpack() calls will iterate over its key-value pairs.
 
-        Raises `OutOfData` when there are no more bytes to unpack.
+        Raises `OutOfData` when there are no more bytes to unpack, and
+        ValueError if the next object is not a map.
         """
         return self._unpack(read_map_header, write_bytes)
+
+    def read_raw_header(self, object write_bytes=None):
+        """assuming the next object is a raw byte string, return its size n,
+        such that raw_bytes(n) will return the string.
+
+        Raises `OutOfData` when there are no more bytes to unpack, and
+        ValueError if the next object is not a raw.
+        """
+        return self._unpack(read_raw_header, write_bytes)
 
     def __iter__(self):
         return self
@@ -398,3 +410,4 @@ cdef class Unpacker(object):
 
     #def _off(self):
     #    return self.buf_head
+

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -525,41 +525,29 @@ class Packer(object):
             return self._pack(self._default(obj), nest_limit - 1)
         raise TypeError("Cannot serialize %r" % obj)
 
-    def pack(self, obj):
-        self._pack(obj)
+    def _get_buffer(self):
         ret = self._buffer.getvalue()
         if self._autoreset:
             self._buffer = StringIO()
         elif USING_STRINGBUILDER:
             self._buffer = StringIO(ret)
         return ret
+
+    def pack(self, obj):
+        self._pack(obj)
+        return self._get_buffer()
 
     def pack_map_pairs(self, pairs):
         self._fb_pack_map_pairs(len(pairs), pairs)
-        ret = self._buffer.getvalue()
-        if self._autoreset:
-            self._buffer = StringIO()
-        elif USING_STRINGBUILDER:
-            self._buffer = StringIO(ret)
-        return ret
+        return self._get_buffer()
 
     def pack_array_header(self, n):
         self._fb_pack_array_header(n)
-        ret = self._buffer.getvalue()
-        if self._autoreset:
-            self._buffer = StringIO()
-        elif USING_STRINGBUILDER:
-            self._buffer = StringIO(ret)
-        return ret
+        return self._get_buffer()
 
     def pack_map_header(self, n):
         self._fb_pack_map_header(n)
-        ret = self._buffer.getvalue()
-        if self._autoreset:
-            self._buffer = StringIO()
-        elif USING_STRINGBUILDER:
-            self._buffer = StringIO(ret)
-        return ret
+        return self._get_buffer()
 
     def _fb_pack_array_header(self, n):
         if n <= 0x0f:

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -52,6 +52,7 @@ EX_SKIP                 = 0
 EX_CONSTRUCT            = 1
 EX_READ_ARRAY_HEADER    = 2
 EX_READ_MAP_HEADER      = 3
+EX_READ_RAW_HEADER      = 4
 
 TYPE_IMMEDIATE          = 0
 TYPE_ARRAY              = 1
@@ -280,7 +281,6 @@ class Unpacker(object):
             obj = struct.unpack("b", c)[0]
         elif b & 0b11100000 == 0b10100000:
             n = b & 0b00011111
-            obj = self._fb_read(n, write_bytes)
             typ = TYPE_RAW
         elif b & 0b11110000 == 0b10010000:
             n = b & 0b00001111
@@ -316,11 +316,9 @@ class Unpacker(object):
             obj = struct.unpack(">q", self._fb_read(8, write_bytes))[0]
         elif b == 0xda:
             n = struct.unpack(">H", self._fb_read(2, write_bytes))[0]
-            obj = self._fb_read(n, write_bytes)
             typ = TYPE_RAW
         elif b == 0xdb:
             n = struct.unpack(">I", self._fb_read(4, write_bytes))[0]
-            obj = self._fb_read(n, write_bytes)
             typ = TYPE_RAW
         elif b == 0xdc:
             n = struct.unpack(">H", self._fb_read(2, write_bytes))[0]
@@ -345,9 +343,13 @@ class Unpacker(object):
             if typ != TYPE_ARRAY:
                 raise UnpackValueError("Expected array")
             return n
-        if execute == EX_READ_MAP_HEADER:
+        elif execute == EX_READ_MAP_HEADER:
             if typ != TYPE_MAP:
                 raise UnpackValueError("Expected map")
+            return n
+        elif execute == EX_READ_RAW_HEADER:
+            if typ != TYPE_RAW:
+                raise UnpackValueError("Expected raw")
             return n
         # TODO should we eliminate the recursion?
         if typ == TYPE_ARRAY:
@@ -387,6 +389,7 @@ class Unpacker(object):
         if execute == EX_SKIP:
             return
         if typ == TYPE_RAW:
+            obj = self._fb_read(n, write_bytes)
             if self._encoding is not None:
                 obj = obj.decode(self._encoding, self._unicode_errors)
             return obj
@@ -418,6 +421,11 @@ class Unpacker(object):
 
     def read_map_header(self, write_bytes=None):
         ret = self._fb_unpack(EX_READ_MAP_HEADER, write_bytes)
+        self._fb_consume()
+        return ret
+
+    def read_raw_header(self, write_bytes=None):
+        ret = self._fb_unpack(EX_READ_RAW_HEADER, write_bytes)
         self._fb_consume()
         return ret
 

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -130,6 +130,18 @@ def testMapSize(sizes=[0, 5, 50, 1000]):
     for size in sizes:
         assert unpacker.unpack() == dict((i, i * 2) for i in range(size))
 
+def testRawSize(sizes=[0, 5, 20, 50, 1000]):
+    bio = six.BytesIO()
+    packer = Packer()
+    for size in sizes:
+        bio.write(packer.pack_raw_header(size))
+        bio.write('!' * size)
+
+    bio.seek(0)
+    unpacker = Unpacker(bio)
+    for size in sizes:
+        assert unpacker.unpack() == '!' * size
+
 
 class odict(dict):
     '''Reimplement OrderedDict to run test on Python 2.6'''

--- a/test/test_read_size.py
+++ b/test/test_read_size.py
@@ -1,66 +1,68 @@
 """Test Unpacker's read_array_header and read_map_header methods"""
+from pytest import raises
 from msgpack import packb, Unpacker, OutOfData
 UnexpectedTypeException = ValueError
 
-def test_read_array_header():
+def test_read_array_header(size=3):
     unpacker = Unpacker()
-    unpacker.feed(packb(['a', 'b', 'c']))
-    assert unpacker.read_array_header() == 3
-    assert unpacker.unpack() == b'a'
-    assert unpacker.unpack() == b'b'
-    assert unpacker.unpack() == b'c'
-    try:
-        unpacker.unpack()
-        assert 0, 'should raise exception'
-    except OutOfData:
-        assert 1, 'okay'
+    unpacker.feed(packb([i for i in xrange(size)]))
+    assert unpacker.read_array_header() == size
+    for i in range(size):
+        assert unpacker.unpack() == i
+    raises(OutOfData, unpacker.unpack)
 
 
-def test_read_map_header():
+def test_read_map_header(size=3):
     unpacker = Unpacker()
-    unpacker.feed(packb({'a': 'A'}))
-    assert unpacker.read_map_header() == 1
-    assert unpacker.unpack() == B'a'
-    assert unpacker.unpack() == B'A'
-    try:
-        unpacker.unpack()
-        assert 0, 'should raise exception'
-    except OutOfData:
-        assert 1, 'okay'
+    unpacker.feed(packb(dict((str(i), i) for i in xrange(size))))
+    assert unpacker.read_map_header() == size
+    for i in xrange(size):
+        key = unpacker.unpack()
+        assert unpacker.unpack() == int(key)
+    raises(OutOfData, unpacker.unpack)
+
+
+def test_read_raw_header(size=3):
+    unpacker = Unpacker()
+    exp = B'!' * size
+    unpacker.feed(packb(exp))
+    print 'fed', len(packb(exp)), 'bytes', repr(packb(exp))
+    assert unpacker.read_raw_header() == size
+    assert unpacker.read_bytes(size) == exp
+    raises(OutOfData, unpacker.unpack)
+
+
+def test_read_various_sizes():
+    for test in [test_read_array_header, test_read_map_header, test_read_raw_header]:
+        for size in [0, 5, 20, 30, ]: # should also test 65536, but slow in fallback under CPython
+            test(size)
+
 
 def test_incorrect_type_array():
     unpacker = Unpacker()
     unpacker.feed(packb(1))
-    try:
-        unpacker.read_array_header()
-        assert 0, 'should raise exception'
-    except UnexpectedTypeException:
-        assert 1, 'okay'
+    raises(UnexpectedTypeException, unpacker.read_array_header)
+
 
 def test_incorrect_type_map():
     unpacker = Unpacker()
     unpacker.feed(packb(1))
-    try:
-        unpacker.read_map_header()
-        assert 0, 'should raise exception'
-    except UnexpectedTypeException:
-        assert 1, 'okay'
+    raises(UnexpectedTypeException, unpacker.read_map_header)
+
+
+def test_incorrect_type_raw():
+    unpacker = Unpacker()
+    unpacker.feed(packb(1))
+    raises(UnexpectedTypeException, unpacker.read_raw_header)
+
 
 def test_correct_type_nested_array():
     unpacker = Unpacker()
     unpacker.feed(packb({'a': ['b', 'c', 'd']}))
-    try:
-        unpacker.read_array_header()
-        assert 0, 'should raise exception'
-    except UnexpectedTypeException:
-        assert 1, 'okay'
+    raises(UnexpectedTypeException, unpacker.read_array_header)
+
 
 def test_incorrect_type_nested_map():
     unpacker = Unpacker()
     unpacker.feed(packb([{'a': 'b'}]))
-    try:
-        unpacker.read_map_header()
-        assert 0, 'should raise exception'
-    except UnexpectedTypeException:
-        assert 1, 'okay'
-
+    raises(UnexpectedTypeException, unpacker.read_map_header)


### PR DESCRIPTION
For consistency with array and map.

This may be useful for #48 and provides a way around #55 until `max_buffer_size` is implemented.