### PR TITLE
Added support for the Mapping Protocol

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -160,7 +160,7 @@ cdef class Packer(object):
                     if ret != 0: break
                     ret = self._pack(v, nest_limit-1)
                     if ret != 0: break
-        elif PyDict_Check(o):
+        elif PyDict_Check(o) or PyMapping_Check(o):
             ret = msgpack_pack_map(&self.pk, len(o))
             if ret == 0:
                 for k, v in o.items():

--- a/test/test_subtype.py
+++ b/test/test_subtype.py
@@ -2,13 +2,47 @@
 # coding: utf-8
 
 from msgpack import packb, unpackb
-from collections import namedtuple
+from collections import namedtuple, Mapping, MutableMapping
 
 class MyList(list):
     pass
 
 class MyDict(dict):
     pass
+
+class MyMapping(Mapping):
+    
+    def __init__(self):
+        self._map = dict()
+
+    def __getitem__(self, key):
+        return self._map[key]
+
+    def __iter__(self):
+        return iter(self._map)
+
+    def __len__(self):
+        return len(self._map)
+
+class MyMutableMapping(MutableMapping):
+    
+    def __init__(self):
+        self._map = dict()
+
+    def __getitem__(self, key):
+        return self._map[key]
+
+    def __setitem__(self, key, value):
+        self._map[key] = value
+
+    def __delitem__(self, key):
+        del(self._map[key])
+
+    def __iter__(self):
+        return iter(self._map)
+
+    def __len__(self):
+        return len(self._map)
 
 class MyTuple(tuple):
     pass
@@ -17,5 +51,7 @@ MyNamedTuple = namedtuple('MyNamedTuple', 'x y')
 
 def test_types():
     assert packb(MyDict()) == packb(dict())
+    assert packb(MyMapping()) == packb(dict())
+    assert packb(MyMutableMapping()) == packb(dict())
     assert packb(MyList()) == packb(list())
     assert packb(MyNamedTuple(1, 2)) == packb((1, 2))


### PR DESCRIPTION
The packer allows to pack also objects that implement the Mapping Protocol, i.e. the `collections.Mapping` and `collections.MutableMapping`.
