### PR TITLE
* msgpack/exceptions.py: Fix typo in error message.

### DIFF
--- a/msgpack/exceptions.py
+++ b/msgpack/exceptions.py
@@ -20,7 +20,7 @@ class ExtraData(ValueError):
         self.extra = extra
 
     def __str__(self):
-        return "unpack(b) recieved extra data."
+        return "unpack(b) received extra data."
 
 class PackException(Exception):
     pass


### PR DESCRIPTION
Hi,

there's a typo in one of the error messages, simple fix attached.

Lieven
