### PR TITLE
Support of bytearray in msgpack/fallback.py

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -194,7 +194,7 @@ class Unpacker(object):
         if isinstance(next_bytes, array.array):
             next_bytes = next_bytes.tostring()
         elif isinstance(next_bytes, bytearray):
-            next_bytes = str(next_bytes)
+            next_bytes = (bytes if PY3 else str)(next_bytes)
         assert self._fb_feeding
         if self._fb_buf_n + len(next_bytes) > self._max_buffer_size:
             raise BufferFull

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 from msgpack import packb, unpackb
+import sys
 
 
 def test_unpack_buffer():
@@ -16,5 +17,7 @@ def test_unpack_bytearray():
     buf = bytearray(packb(('foo', 'bar')))
     obj = unpackb(buf, use_list=1)
     assert [b'foo', b'bar'] == obj
-    assert all(type(s)==str for s in obj)
+    expected_type = bytes if sys.version_info[0] == 3 else str
+    assert all(type(s)==expected_type for s in obj)
+
 


### PR DESCRIPTION
Pure-python implementation of unpack returns bytearrays instead of strings, if packed data is bytearray 

In [1]: import msgpack
In [2]: msgpack.unpackb(bytearray(b'\xa3foo'))
Out[2]: bytearray(b'foo')

Patch fixes this case
