### PR TITLE
Always raise TypeError for wrong argument types

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -52,7 +52,7 @@ cdef inline init_ctx(unpack_context *ctx,
     ctx.user.object_hook = ctx.user.list_hook = <PyObject*>NULL
 
     if object_hook is not None and object_pairs_hook is not None:
-        raise ValueError("object_pairs_hook and object_hook are mutually exclusive.")
+        raise TypeError("object_pairs_hook and object_hook are mutually exclusive.")
 
     if object_hook is not None:
         if not PyCallable_Check(object_hook):
@@ -227,7 +227,7 @@ cdef class Unpacker(object):
         if file_like:
             self.file_like_read = file_like.read
             if not PyCallable_Check(self.file_like_read):
-                raise ValueError("`file_like.read` must be a callable.")
+                raise TypeError("`file_like.read` must be a callable.")
         if not max_buffer_size:
             max_buffer_size = INT_MAX
         if read_size > max_buffer_size:

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -159,7 +159,7 @@ class Unpacker(object):
             self._fb_feeding = True
         else:
             if not callable(file_like.read):
-                raise ValueError("`file_like.read` must be callable")
+                raise TypeError("`file_like.read` must be callable")
             self.file_like = file_like
             self._fb_feeding = False
         self._fb_buffers = []
@@ -179,16 +179,16 @@ class Unpacker(object):
         self._ext_hook = ext_hook
 
         if list_hook is not None and not callable(list_hook):
-            raise ValueError('`list_hook` is not callable')
+            raise TypeError('`list_hook` is not callable')
         if object_hook is not None and not callable(object_hook):
-            raise ValueError('`object_hook` is not callable')
+            raise TypeError('`object_hook` is not callable')
         if object_pairs_hook is not None and not callable(object_pairs_hook):
-            raise ValueError('`object_pairs_hook` is not callable')
+            raise TypeError('`object_pairs_hook` is not callable')
         if object_hook is not None and object_pairs_hook is not None:
-            raise ValueError("object_pairs_hook and object_hook are mutually "
-                             "exclusive")
+            raise TypeError("object_pairs_hook and object_hook are mutually "
+                            "exclusive")
         if not callable(ext_hook):
-            raise ValueError("`ext_hook` is not callable")
+            raise TypeError("`ext_hook` is not callable")
 
     def feed(self, next_bytes):
         if isinstance(next_bytes, array.array):

--- a/test/test_obj.py
+++ b/test/test_obj.py
@@ -31,7 +31,7 @@ def test_decode_pairs_hook():
     assert unpacked[1] == prod_sum
 
 def test_only_one_obj_hook():
-    with raises(ValueError):
+    with raises(TypeError):
         unpackb(b'', object_hook=lambda x: x, object_pairs_hook=lambda x: x)
 
 def test_bad_hook():


### PR DESCRIPTION
The code that checks whether hooks are callable() (and some other type
checks) should always raise TypeError on failure. Before this change,
both ValueError and TypeError were used in an inconsistent way (C
extension and Python implementation were not the same).
