### PR TITLE
Cosmetic changes to fix Cython warnings

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -221,7 +221,8 @@ cdef class Unpacker(object):
                  object object_hook=None, object object_pairs_hook=None, object list_hook=None,
                  str encoding=None, str unicode_errors='strict', int max_buffer_size=0,
                  object ext_hook=ExtType):
-        cdef char *cenc=NULL, *cerr=NULL
+        cdef char *cenc=NULL,
+        cdef char *cerr=NULL
 
         self.file_like = file_like
         if file_like:


### PR DESCRIPTION
Put declarations on separate line to avoid warnings like this:

  Non-trivial type declarators in shared declaration (e.g. mix
  of pointers and values). Each pointer declaration should be
  on its own line.
