### PR TITLE
Initialize buffer to avoid reading uninitialized memory

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -257,6 +257,9 @@ cdef class Unpacker(object):
                 self.unicode_errors = unicode_errors
             cerr = PyBytes_AsString(self.unicode_errors)
 
+        if file_like:
+            self.read_from_file()  # initialize buffer (issue #83)
+
         init_ctx(&self.ctx, object_hook, object_pairs_hook, list_hook,
                  ext_hook, use_list, cenc, cerr)
 


### PR DESCRIPTION
When parsing from a file-like object, first initialize the buffer that
is used by the parser, since otherwise read_array_header(),
read_map_header(), and possibly other low-level parsing functions read
uninitialized memory.

See issue #83.
