### PR TITLE
Fix case where string encoding overhead is larger than needed

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -595,7 +595,7 @@ class Packer(object):
                 n = len(obj)
                 if n <= 0x1f:
                     self._buffer.write(struct.pack('B', 0xa0 + n))
-                elif self._use_bin_type and n <= 0xff:
+                elif n <= 0xff:
                     self._buffer.write(struct.pack('>BB', 0xd9, n))
                 elif n <= 0xffff:
                     self._buffer.write(struct.pack(">BH", 0xda, n))

--- a/msgpack/pack_template.h
+++ b/msgpack/pack_template.h
@@ -667,7 +667,7 @@ static inline int msgpack_pack_raw(msgpack_packer* x, size_t l)
     if (l < 32) {
         unsigned char d = 0xa0 | (uint8_t)l;
         msgpack_pack_append_buffer(x, &TAKE8_8(d), 1);
-    } else if (x->use_bin_type && l < 256) {  // str8 is new format introduced with bin.
+    } else if (l < 256) {  // str8 is new format introduced with bin.
         unsigned char buf[2] = {0xd9, (uint8_t)l};
         msgpack_pack_append_buffer(x, buf, 2);
     } else if (l < 65536) {

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -4,8 +4,8 @@
 from msgpack import packb, unpackb
 
 
-def check(length, obj):
-    v = packb(obj)
+def check(length, obj, use_bin_type=False):
+    v = packb(obj, use_bin_type=use_bin_type)
     assert len(v) == length, \
         "%r length should be %r but get %r" % (obj, length, len(v))
     assert unpackb(v, use_list=0) == obj
@@ -37,20 +37,31 @@ def test_9():
               1.0, 0.1, -0.1, -1.0]:
         check(9, o)
 
-
-def check_raw(overhead, num):
+def check_str(overhead, num):
     check(num + overhead, b" " * num)
 
-def test_fixraw():
-    check_raw(1, 0)
-    check_raw(1, (1<<5) - 1)
+def check_bin(overhead, num):
+    check(num + overhead, b" " * num, use_bin_type=True)
+
+def test_raw_short():
+    check_str(1, 0)
+    check_str(1, (1<<5) - 1)
+    check_str(2, 1<<5)
+    check_str(2, (1<<8) - 1)
+
+    check_bin(2, 0)
+    check_bin(2, (1<<8) - 1)
 
 def test_raw16():
-    check_raw(3, 1<<5)
-    check_raw(3, (1<<16) - 1)
+    check_str(3, 1<<8)
+    check_str(3, (1<<16) - 1)
+
+    check_bin(3, 1<<8)
+    check_bin(3, (1<<16) - 1)
 
 def test_raw32():
-    check_raw(5, 1<<16)
+    check_str(5, 1<<16)
+    check_bin(5, 1<<16)
 
 
 def check_array(overhead, num):


### PR DESCRIPTION
According to the spec "serializers SHOULD use the format which
represents the data in the smallest number of bytes". This is not true
for strings between 32 and (2^8)-1 bytes which has an encoding
overhead of 3 bytes instead of the required 2.

My guess is that the somewhat strange conditional in fallback.py:598
(and cython equivalent) is to make sure that old raw type test
cases in test_case.py that test for encoding overhead succeeds.

This commit updates the test case to test for the encoding overhead
for both str and bin types of various lengths.
