### PR TITLE
add support for pypy3

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -23,7 +23,10 @@ if hasattr(sys, 'pypy_version_info'):
     # cStringIO is slow on PyPy, StringIO is faster.  However: PyPy's own
     # StringBuilder is fastest.
     from __pypy__ import newlist_hint
-    from __pypy__.builders import StringBuilder
+    try:
+        from __pypy__.builders import BytesBuilder as StringBuilder
+    except ImportError:
+        from __pypy__.builders import StringBuilder
     USING_STRINGBUILDER = True
     class StringIO(object):
         def __init__(self, s=b''):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy
+envlist = py26,py27,py32,py33,py34,pypy,pypy3
 
 [testenv]
 deps=


### PR DESCRIPTION
This will make msgpack-python support pypy3 (by import BytesBuilder instead of StringBuilder when possible)
Since msgpack-python support python3, I think it should support pypy3 too.
