### PR TITLE
Use wheelhouse for cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 sudo: false
+cache:
+    directories:
+        - wheelhouse
+
 language: python
 python:
     - 2.7
 
 install:
-    - pip install tox cython
+    - pip install wheel tox
+    - ls -la wheelhouse
+    - if [ ! -f wheelhouse/Cython-0.21.2-cp27-none-linux_x86_64.whl ] ; then pip wheel cython ; fi
+    - pip install wheelhouse/Cython-0.21.2-cp27-none-linux_x86_64.whl
     - cython --cplus msgpack/_packer.pyx msgpack/_unpacker.pyx
 
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,6 @@ deps=
 
 changedir=test
 commands=
-    c: python -c 'from msgpack import _packer, _unpacker' && py.test
+    c: python -c 'from msgpack import _packer, _unpacker'
+    c: py.test
     pure: py.test


### PR DESCRIPTION
Building Cython for every test makes test slow.
Travis-CI's new Docker based environment supports cache.  So prepare whl for Cython.