### PR TITLE
tests: add pytest 2.3 compatibility

### DIFF
--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -16,7 +16,7 @@ def test_unpack_array_header_from_file():
         unpacker.unpack()
 
 
-@mark.skipif(not hasattr(sys, 'getrefcount'),
+@mark.skipif("not hasattr(sys, 'getrefcount') == True",
              reason='sys.getrefcount() is needed to pass this test')
 def test_unpacker_hook_refcnt():
     result = []


### PR DESCRIPTION
Adjust the skipif conditional to use the older pytest 2.3 syntax.

(This allows the tests to pass with the system pytest package on RHEL 7.0, since RHEL 7.0 ships pytest 2.3.5. See downstream bug https://bugzilla.redhat.com/1182808)