### PR TITLE
Support for serializing to Str and Bin from Python 2.X

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -2,6 +2,7 @@
 #cython: embedsignature=True
 
 from cpython cimport *
+from cpython.version cimport PY_MAJOR_VERSION
 from libc.stdlib cimport *
 from libc.string cimport *
 from libc.limits cimport *
@@ -9,6 +10,8 @@ from libc.limits cimport *
 from msgpack.exceptions import PackValueError
 from msgpack import ExtType
 
+cdef extern from "Python.h":
+    cdef int PyByteArray_Check(object o)
 
 cdef extern from "pack.h":
     struct msgpack_packer:
@@ -152,15 +155,31 @@ cdef class Packer(object):
                 else:
                    dval = o
                    ret = msgpack_pack_double(&self.pk, dval)
-            elif PyBytes_Check(o):
+            elif PyByteArray_Check(o):
                 L = len(o)
                 if L > (2**32)-1:
-                    raise ValueError("bytes is too large")
+                    raise ValueError("bytearray is too large")
                 rawval = o
                 if self.pk.use_bin_type:
                     ret = msgpack_pack_bin(&self.pk, L)
                 else:
                     ret = msgpack_pack_str(&self.pk, L)
+                if ret == 0:
+                    ret = msgpack_pack_raw_body(&self.pk, rawval, L)
+            elif PyBytes_Check(o):
+                L = len(o)
+                if L > (2**32)-1:
+                    raise ValueError("bytes is too large")
+                rawval = o
+                # In Python 2.X, 'bytes' is equivalent to 'str' so we don't convert
+                # strings implicitly to bin
+                if PY_MAJOR_VERSION < 3:
+                    ret = msgpack_pack_str(&self.pk, L)
+                else:
+                    if self.pk.use_bin_type:
+                        ret = msgpack_pack_bin(&self.pk, L)
+                    else:
+                        ret = msgpack_pack_str(&self.pk, L)
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, rawval, L)
             elif PyUnicode_Check(o):
@@ -169,7 +188,7 @@ cdef class Packer(object):
                 o = PyUnicode_AsEncodedString(o, self.encoding, self.unicode_errors)
                 L = len(o)
                 if L > (2**32)-1:
-                    raise ValueError("dict is too large")
+                    raise ValueError("unicode string is too large")
                 rawval = o
                 ret = msgpack_pack_str(&self.pk, len(o))
                 if ret == 0:

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -28,7 +28,7 @@ cdef extern from "pack.h":
     int msgpack_pack_double(msgpack_packer* pk, double d)
     int msgpack_pack_array(msgpack_packer* pk, size_t l)
     int msgpack_pack_map(msgpack_packer* pk, size_t l)
-    int msgpack_pack_raw(msgpack_packer* pk, size_t l)
+    int msgpack_pack_str(msgpack_packer* pk, size_t l)
     int msgpack_pack_bin(msgpack_packer* pk, size_t l)
     int msgpack_pack_raw_body(msgpack_packer* pk, char* body, size_t l)
     int msgpack_pack_ext(msgpack_packer* pk, char typecode, size_t l)
@@ -168,7 +168,7 @@ cdef class Packer(object):
                 if L > (2**32)-1:
                     raise ValueError("dict is too large")
                 rawval = o
-                ret = msgpack_pack_raw(&self.pk, len(o))
+                ret = msgpack_pack_str(&self.pk, len(o))
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, rawval, len(o))
             elif PyDict_CheckExact(o):

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -157,7 +157,10 @@ cdef class Packer(object):
                 if L > (2**32)-1:
                     raise ValueError("bytes is too large")
                 rawval = o
-                ret = msgpack_pack_bin(&self.pk, L)
+                if self.pk.use_bin_type:
+                    ret = msgpack_pack_bin(&self.pk, L)
+                else:
+                    ret = msgpack_pack_str(&self.pk, L)
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, rawval, L)
             elif PyUnicode_Check(o):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -664,7 +664,7 @@ class Packer(object):
             if isinstance(obj, bytes):
                 # In Python 2.X, 'bytes' is equivalent to 'str' so we don't convert
                 # strings implicitly to bin
-                if sys.version_info.major < 3:
+                if sys.version_info[0] < 3:
                     return self.pack_str(obj)
                 else:
                     if self._use_bin_type:

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -36,6 +36,8 @@ if hasattr(sys, 'pypy_version_info'):
             else:
                 self.builder = StringBuilder()
         def write(self, s):
+            if isinstance(s, bytearray):
+                s = str(s)
             self.builder.append(s)
         def getvalue(self):
             return self.builder.build()

--- a/msgpack/pack.h
+++ b/msgpack/pack.h
@@ -67,7 +67,7 @@ static inline int msgpack_pack_array(msgpack_packer* pk, unsigned int n);
 
 static inline int msgpack_pack_map(msgpack_packer* pk, unsigned int n);
 
-static inline int msgpack_pack_raw(msgpack_packer* pk, size_t l);
+static inline int msgpack_pack_str(msgpack_packer* pk, size_t l);
 static inline int msgpack_pack_bin(msgpack_packer* pk, size_t l);
 static inline int msgpack_pack_raw_body(msgpack_packer* pk, const void* b, size_t l);
 

--- a/msgpack/pack_template.h
+++ b/msgpack/pack_template.h
@@ -686,9 +686,6 @@ static inline int msgpack_pack_str(msgpack_packer* x, size_t l)
  */
 static inline int msgpack_pack_bin(msgpack_packer *x, size_t l)
 {
-    if (!x->use_bin_type) {
-        return msgpack_pack_str(x, l);
-    }
     if (l < 256) {
         unsigned char buf[2] = {0xc4, (unsigned char)l};
         msgpack_pack_append_buffer(x, buf, 2);

--- a/msgpack/pack_template.h
+++ b/msgpack/pack_template.h
@@ -662,7 +662,7 @@ static inline int msgpack_pack_map(msgpack_packer* x, unsigned int n)
  * Raw
  */
 
-static inline int msgpack_pack_raw(msgpack_packer* x, size_t l)
+static inline int msgpack_pack_str(msgpack_packer* x, size_t l)
 {
     if (l < 32) {
         unsigned char d = 0xa0 | (uint8_t)l;
@@ -687,7 +687,7 @@ static inline int msgpack_pack_raw(msgpack_packer* x, size_t l)
 static inline int msgpack_pack_bin(msgpack_packer *x, size_t l)
 {
     if (!x->use_bin_type) {
-        return msgpack_pack_raw(x, l);
+        return msgpack_pack_str(x, l);
     }
     if (l < 256) {
         unsigned char buf[2] = {0xc4, (unsigned char)l};

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -49,7 +49,7 @@ def test_max_str_len():
 
 def test_max_bin_len():
     d = b'x' * 3
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         d = bytearray(d)
     packed = packb(d, use_bin_type=True)
 

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
 import pytest
 
 from msgpack import packb, unpackb, Packer, Unpacker, ExtType
@@ -48,6 +49,8 @@ def test_max_str_len():
 
 def test_max_bin_len():
     d = b'x' * 3
+    if sys.version_info.major < 3:
+        d = bytearray(d)
     packed = packb(d, use_bin_type=True)
 
     unpacker = Unpacker(max_bin_len=3)

--- a/test/test_newspec.py
+++ b/test/test_newspec.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import sys
 from msgpack import packb, unpackb, ExtType
 
 
@@ -21,47 +22,92 @@ def test_str8():
 
 
 def test_bin8():
-    header = b'\xc4'
+    bin_header = b'\xc4'
     data = b''
+    # Test raw encoding of strings in Python 2.X even with bin type enabled
+    if sys.version_info.major < 3:
+        b = packb(data, use_bin_type=True)
+        assert len(b) == len(data) + 1
+        assert b[0:1] == b'\xa0'
+        assert b[1:] == data
+        assert unpackb(b) == data
+        data = bytearray(data)
     b = packb(data, use_bin_type=True)
     assert len(b) == len(data) + 2
-    assert b[0:2] == header + b'\x00'
+    assert b[0:2] == bin_header + b'\x00'
     assert b[2:] == data
     assert unpackb(b) == data
 
     data = b'x' * 255
+    # Test raw encoding of strings in Python 2.X even with bin type enabled
+    if sys.version_info.major < 3:
+        b = packb(data, use_bin_type=True)
+        assert len(b) == len(data) + 2
+        assert b[0:2] == b'\xd9' + b'\xff'
+        assert b[2:] == data
+        assert unpackb(b) == data
+        data = bytearray(data)
     b = packb(data, use_bin_type=True)
     assert len(b) == len(data) + 2
-    assert b[0:2] == header + b'\xff'
+    assert b[0:2] == bin_header + b'\xff'
     assert b[2:] == data
     assert unpackb(b) == data
 
 
 def test_bin16():
-    header = b'\xc5'
+    str_header = b'\xda'
+    bin_header = b'\xc5'
     data = b'x' * 256
+    # Test raw encoding of strings in Python 2.X even with bin type enabled
+    if sys.version_info.major < 3:
+        b = packb(data, use_bin_type=True)
+        assert len(b) == len(data) + 3
+        assert b[0:1] == str_header
+        assert b[1:3] == b'\x01\x00'
+        assert b[3:] == data
+        assert unpackb(b) == data
+        data = bytearray(data)
     b = packb(data, use_bin_type=True)
     assert len(b) == len(data) + 3
-    assert b[0:1] == header
+    assert b[0:1] == bin_header
     assert b[1:3] == b'\x01\x00'
     assert b[3:] == data
     assert unpackb(b) == data
 
     data = b'x' * 65535
+    # Test raw encoding of strings in Python 2.X even with bin type enabled
+    if sys.version_info.major < 3:
+        b = packb(data, use_bin_type=True)
+        assert len(b) == len(data) + 3
+        assert b[0:1] == str_header
+        assert b[1:3] == b'\xff\xff'
+        assert b[3:] == data
+        assert unpackb(b) == data
+        data = bytearray(data)
     b = packb(data, use_bin_type=True)
     assert len(b) == len(data) + 3
-    assert b[0:1] == header
+    assert b[0:1] == bin_header
     assert b[1:3] == b'\xff\xff'
     assert b[3:] == data
     assert unpackb(b) == data
 
 
 def test_bin32():
-    header = b'\xc6'
+    str_header = b'\xdb'
+    bin_header = b'\xc6'
     data = b'x' * 65536
+    # Test raw encoding of strings in Python 2.X even with bin type enabled
+    if sys.version_info.major < 3:
+        b = packb(data, use_bin_type=True)
+        assert len(b) == len(data) + 5
+        assert b[0:1] == str_header
+        assert b[1:5] == b'\x00\x01\x00\x00'
+        assert b[5:] == data
+        assert unpackb(b) == data
+        data = bytearray(data)
     b = packb(data, use_bin_type=True)
     assert len(b) == len(data) + 5
-    assert b[0:1] == header
+    assert b[0:1] == bin_header
     assert b[1:5] == b'\x00\x01\x00\x00'
     assert b[5:] == data
     assert unpackb(b) == data

--- a/test/test_newspec.py
+++ b/test/test_newspec.py
@@ -25,7 +25,7 @@ def test_bin8():
     bin_header = b'\xc4'
     data = b''
     # Test raw encoding of strings in Python 2.X even with bin type enabled
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         b = packb(data, use_bin_type=True)
         assert len(b) == len(data) + 1
         assert b[0:1] == b'\xa0'
@@ -40,7 +40,7 @@ def test_bin8():
 
     data = b'x' * 255
     # Test raw encoding of strings in Python 2.X even with bin type enabled
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         b = packb(data, use_bin_type=True)
         assert len(b) == len(data) + 2
         assert b[0:2] == b'\xd9' + b'\xff'
@@ -59,7 +59,7 @@ def test_bin16():
     bin_header = b'\xc5'
     data = b'x' * 256
     # Test raw encoding of strings in Python 2.X even with bin type enabled
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         b = packb(data, use_bin_type=True)
         assert len(b) == len(data) + 3
         assert b[0:1] == str_header
@@ -76,7 +76,7 @@ def test_bin16():
 
     data = b'x' * 65535
     # Test raw encoding of strings in Python 2.X even with bin type enabled
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         b = packb(data, use_bin_type=True)
         assert len(b) == len(data) + 3
         assert b[0:1] == str_header
@@ -97,7 +97,7 @@ def test_bin32():
     bin_header = b'\xc6'
     data = b'x' * 65536
     # Test raw encoding of strings in Python 2.X even with bin type enabled
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         b = packb(data, use_bin_type=True)
         assert len(b) == len(data) + 5
         assert b[0:1] == str_header


### PR DESCRIPTION
When setting `use_bin_type=True` in Python 2.X, we lose the ability to serialize strings as Str (Raw); instead, all `str` objects are serialized as Bin.

You probably already know that in Python 2.X, `bytes == str` so the serializer has no way to distinguish between encoded and un-encoded data passed as a string. Unfortunately I found no mechanism to use `default` to get the desired behavior (`str` => Str and `[something]` => Bin). It was either "everything is Str" or "everything is Bin".

Proposed change:
* backward-compatible behavior when `use_bin_types == False` (everything => Str (Raw))
* add serialization of `bytearray` to Bin or Str as determined by `use_bin_types`
* enables (`str` => Str, `bytearray` => Bin) in Python 2.X
* existing Python 3.X behavior unchanged: (`str` => Str, `bytes` => Bin)

This is my first pull request to an open source project so please go easy! I'd really like to help support the community and I'm very excited to use msgpack. It's already sped up one of my protocols by 1000x and I'd love to keep helping to improve it.

Thoughts?