### PR TITLE
Packer: check type strictly

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -13,6 +13,7 @@ Changes
 * Reduce compiler warnings while building extension module
 * unpack() now accepts ext_hook argument like Unpacker and unpackb()
 * Update Cython version to 0.23.4
+* default function is called when integer overflow
 
 
 0.4.6

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -135,7 +135,7 @@ cdef class Packer(object):
                     ret = msgpack_pack_false(&self.pk)
             elif PyLong_Check(o):
                 # PyInt_Check(long) is True for Python 3.
-                # Sow we should test long before int.
+                # So we should test long before int.
                 try:
                     if o > 0:
                         ullval = o
@@ -143,7 +143,7 @@ cdef class Packer(object):
                     else:
                         llval = o
                         ret = msgpack_pack_long_long(&self.pk, llval)
-                except OverflowError, oe:
+                except OverflowError as oe:
                     if not default_used and self._default is not None:
                         o = self._default(o)
                         default_used = True

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -213,7 +213,7 @@ cdef class Packer(object):
                         if ret != 0: break
                         ret = self._pack(v, nest_limit-1)
                         if ret != 0: break
-            elif isinstance(o, ExtType):
+            elif type(o) is ExtType if strict_types else isinstance(o, ExtType):
                 # This should be before Tuple because ExtType is namedtuple.
                 longval = o.code
                 rawval = o.data

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -55,7 +55,7 @@ cdef class Packer(object):
         Convert unicode to bytes with this encoding. (default: 'utf-8')
     :param str unicode_errors:
         Error handler for encoding unicode. (default: 'strict')
-    :param bool precise_mode:
+    :param bool strict_types:
         If set to true, types will be checked to be exact. Derived classes
         from serializeable types will not be serialized and will be
         treated as unsupported type and forwarded to default.
@@ -77,7 +77,7 @@ cdef class Packer(object):
     cdef object _berrors
     cdef char *encoding
     cdef char *unicode_errors
-    cdef bint precise_mode
+    cdef bint strict_types
     cdef bool use_float
     cdef bint autoreset
 
@@ -91,11 +91,11 @@ cdef class Packer(object):
 
     def __init__(self, default=None, encoding='utf-8', unicode_errors='strict',
                  use_single_float=False, bint autoreset=1, bint use_bin_type=0,
-                 bint precise_mode=0):
+                 bint strict_types=0):
         """
         """
         self.use_float = use_single_float
-        self.precise_mode = precise_mode
+        self.strict_types = strict_types
         self.autoreset = autoreset
         self.pk.use_bin_type = use_bin_type
         if default is not None:
@@ -131,7 +131,7 @@ cdef class Packer(object):
         cdef dict d
         cdef size_t L
         cdef int default_used = 0
-        cdef bint precise = self.precise_mode
+        cdef bint strict_types = self.strict_types
 
         if nest_limit < 0:
             raise PackValueError("recursion limit exceeded.")
@@ -139,12 +139,12 @@ cdef class Packer(object):
         while True:
             if o is None:
                 ret = msgpack_pack_nil(&self.pk)
-            elif PyBool_Check(o) if precise else isinstance(o, bool):
+            elif PyBool_Check(o) if strict_types else isinstance(o, bool):
                 if o:
                     ret = msgpack_pack_true(&self.pk)
                 else:
                     ret = msgpack_pack_false(&self.pk)
-            elif PyLong_CheckExact(o) if precise else PyLong_Check(o):
+            elif PyLong_CheckExact(o) if strict_types else PyLong_Check(o):
                 # PyInt_Check(long) is True for Python 3.
                 # So we should test long before int.
                 try:
@@ -161,17 +161,17 @@ cdef class Packer(object):
                         continue
                     else:
                         raise
-            elif PyInt_CheckExact(o) if precise else PyInt_Check(o):
+            elif PyInt_CheckExact(o) if strict_types else PyInt_Check(o):
                 longval = o
                 ret = msgpack_pack_long(&self.pk, longval)
-            elif PyFloat_CheckExact(o) if precise else PyFloat_Check(o):
+            elif PyFloat_CheckExact(o) if strict_types else PyFloat_Check(o):
                 if self.use_float:
                    fval = o
                    ret = msgpack_pack_float(&self.pk, fval)
                 else:
                    dval = o
                    ret = msgpack_pack_double(&self.pk, dval)
-            elif PyBytes_CheckExact(o) if precise else PyBytes_Check(o):
+            elif PyBytes_CheckExact(o) if strict_types else PyBytes_Check(o):
                 L = len(o)
                 if L > (2**32)-1:
                     raise ValueError("bytes is too large")
@@ -179,7 +179,7 @@ cdef class Packer(object):
                 ret = msgpack_pack_bin(&self.pk, L)
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, rawval, L)
-            elif PyUnicode_CheckExact(o) if precise else PyUnicode_Check(o):
+            elif PyUnicode_CheckExact(o) if strict_types else PyUnicode_Check(o):
                 if not self.encoding:
                     raise TypeError("Can't encode unicode string: no encoding is specified")
                 o = PyUnicode_AsEncodedString(o, self.encoding, self.unicode_errors)
@@ -202,7 +202,7 @@ cdef class Packer(object):
                         if ret != 0: break
                         ret = self._pack(v, nest_limit-1)
                         if ret != 0: break
-            elif not precise and PyDict_Check(o):
+            elif not strict_types and PyDict_Check(o):
                 L = len(o)
                 if L > (2**32)-1:
                     raise ValueError("dict is too large")
@@ -222,7 +222,7 @@ cdef class Packer(object):
                     raise ValueError("EXT data is too large")
                 ret = msgpack_pack_ext(&self.pk, longval, L)
                 ret = msgpack_pack_raw_body(&self.pk, rawval, L)
-            elif PyList_CheckExact(o) if precise else (PyTuple_Check(o) or PyList_Check(o)):
+            elif PyList_CheckExact(o) if strict_types else (PyTuple_Check(o) or PyList_Check(o)):
                 L = len(o)
                 if L > (2**32)-1:
                     raise ValueError("list is too large")

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -55,13 +55,6 @@ cdef class Packer(object):
         Convert unicode to bytes with this encoding. (default: 'utf-8')
     :param str unicode_errors:
         Error handler for encoding unicode. (default: 'strict')
-    :param bool strict_types:
-        If set to true, types will be checked to be exact. Derived classes
-        from serializeable types will not be serialized and will be
-        treated as unsupported type and forwarded to default.
-        Additionally tuples will not be serialized as lists.
-        This is useful when trying to implement accurate serialization 
-        for python types.
     :param bool use_single_float:
         Use single precision float type for float. (default: False)
     :param bool autoreset:
@@ -70,6 +63,13 @@ cdef class Packer(object):
     :param bool use_bin_type:
         Use bin type introduced in msgpack spec 2.0 for bytes.
         It also enable str8 type for unicode.
+    :param bool strict_types:
+        If set to true, types will be checked to be exact. Derived classes
+        from serializeable types will not be serialized and will be
+        treated as unsupported type and forwarded to default.
+        Additionally tuples will not be serialized as lists.
+        This is useful when trying to implement accurate serialization
+        for python types.
     """
     cdef msgpack_packer pk
     cdef object _default

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -608,13 +608,6 @@ class Packer(object):
             Convert unicode to bytes with this encoding. (default: 'utf-8')
     :param str unicode_errors:
         Error handler for encoding unicode. (default: 'strict')
-    :param bool strict_types:
-        If set to true, types will be checked to be exact. Derived classes
-        from serializeable types will not be serialized and will be
-        treated as unsupported type and forwarded to default.
-        Additionally tuples will not be serialized as lists.
-        This is useful when trying to implement accurate serialization 
-        for python types.
     :param bool use_single_float:
         Use single precision float type for float. (default: False)
     :param bool autoreset:
@@ -623,10 +616,17 @@ class Packer(object):
     :param bool use_bin_type:
         Use bin type introduced in msgpack spec 2.0 for bytes.
         It also enable str8 type for unicode.
+    :param bool strict_types:
+        If set to true, types will be checked to be exact. Derived classes
+        from serializeable types will not be serialized and will be
+        treated as unsupported type and forwarded to default.
+        Additionally tuples will not be serialized as lists.
+        This is useful when trying to implement accurate serialization
+        for python types.
     """
     def __init__(self, default=None, encoding='utf-8', unicode_errors='strict',
-                 strict_types=False, use_single_float=False, autoreset=True,
-                 use_bin_type=False):
+                 use_single_float=False, autoreset=True, use_bin_type=False,
+                 strict_types=False):
         self._strict_types = strict_types
         self._use_float = use_single_float
         self._autoreset = autoreset

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -69,6 +69,13 @@ TYPE_EXT                = 5
 DEFAULT_RECURSE_LIMIT = 511
 
 
+def _check_type_strict(obj, t, type=type, tuple=tuple):
+    if type(t) is tuple:
+        return type(obj) in t
+    else:
+        return type(obj) is t
+
+
 def unpack(stream, **kwargs):
     """
     Unpack an object from `stream`.
@@ -601,7 +608,7 @@ class Packer(object):
             Convert unicode to bytes with this encoding. (default: 'utf-8')
     :param str unicode_errors:
         Error handler for encoding unicode. (default: 'strict')
-    :param bool precise_mode:
+    :param bool strict_types:
         If set to true, types will be checked to be exact. Derived classes
         from serializeable types will not be serialized and will be
         treated as unsupported type and forwarded to default.
@@ -618,9 +625,9 @@ class Packer(object):
         It also enable str8 type for unicode.
     """
     def __init__(self, default=None, encoding='utf-8', unicode_errors='strict',
-                 precise_mode=False, use_single_float=False, autoreset=True,
+                 strict_types=False, use_single_float=False, autoreset=True,
                  use_bin_type=False):
-        self._precise_mode = precise_mode
+        self._strict_types = strict_types
         self._use_float = use_single_float
         self._autoreset = autoreset
         self._use_bin_type = use_bin_type
@@ -632,17 +639,11 @@ class Packer(object):
                 raise TypeError("default must be callable")
         self._default = default
 
-    def _check_precise(obj, t, type=type, tuple=tuple):
-        if type(t) is tuple:
-            return type(obj) in t
-        else:
-            return type(obj) is t
-
     def _pack(self, obj, nest_limit=DEFAULT_RECURSE_LIMIT,
-              check=isinstance, check_precise=_check_precise):
+              check=isinstance, check_type_strict=_check_type_strict):
         default_used = False
-        if self._precise_mode:
-            check = check_precise
+        if self._strict_types:
+            check = check_type_strict
             list_types = list
         else:
             list_types = (list, tuple)

--- a/test/test_stricttype.py
+++ b/test/test_stricttype.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+from collections import namedtuple
+from msgpack import packb, unpackb
+
+
+def test_namedtuple():
+    T = namedtuple('T', "foo bar")
+    def default(o):
+        if isinstance(o, T):
+            return dict(o._asdict())
+        raise TypeError('Unsupported type %s' % (type(o),))
+    packed = packb(T(1, 42), strict_types=True, use_bin_type=True, default=default)
+    unpacked = unpackb(packed, encoding='utf-8')
+    assert unpacked == {'foo': 1, 'bar': 42}


### PR DESCRIPTION
Current packer accepts child types and doesn't distinguish list and tuples.
It means you can't hook encoding named tuple with `default` function.

This PR adds `strict_types` option.  When it is enabled, Packer doesn't accept
child types and tuples.

fixes #142
fixes #98

(This PR is follow up of #100 since there were no response from original author.)