### PR TITLE
Travis will now cache dependencies despite having a custom install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache/pip
 language: python
 python:
     - 2.7


### PR DESCRIPTION
See documentation here http://docs.travis-ci.com/user/caching/#pip-cache