### PR TITLE
Support packing memoryview objects

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -36,6 +36,8 @@ if hasattr(sys, 'pypy_version_info'):
             else:
                 self.builder = StringBuilder()
         def write(self, s):
+            if isinstance(s, memoryview):
+                s = s.tobytes()
             self.builder.append(s)
         def getvalue(self):
             return self.builder.build()
@@ -682,7 +684,7 @@ class Packer(object):
                     default_used = True
                     continue
                 raise PackValueError("Integer value out of range")
-            if self._use_bin_type and check(obj, bytes):
+            if self._use_bin_type and check(obj, (bytes, memoryview)):
                 n = len(obj)
                 if n <= 0xff:
                     self._buffer.write(struct.pack('>BB', 0xc4, n))
@@ -693,7 +695,7 @@ class Packer(object):
                 else:
                     raise PackValueError("Bytes is too large")
                 return self._buffer.write(obj)
-            if check(obj, (Unicode, bytes)):
+            if check(obj, (Unicode, bytes, memoryview)):
                 if check(obj, Unicode):
                     if self._encoding is None:
                         raise TypeError(

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+
+from msgpack import packb, unpackb
+
+
+def test_pack_memoryview():
+    data = bytearray(range(256))
+    view = memoryview(data)
+    unpacked = unpackb(packb(view))
+    assert data == unpacked


### PR DESCRIPTION
I am working on a high-throughput scenario where I need to avoid copying memory wherever possible. I frequently create buffers from existing objects and sometimes need to hand them to msgpack.
Unfortunately I could not find a way to pass buffers to the current version of msgpack without copying.
So I wrote this small patch to support packing arbitrary buffer objects to binary data. It works well for my use case.

Things I'm not so sure about:
* Pure Python fallback is not implemented. Its structure is different from the Cython code and I'm not sure what to do exactly.
* I'm not an expert in using this library. Does this interfere with any other functionality?
* Information is lost in the conversion, e.g., shape of Numpy arrays. Since the lib just "swallows" everything that is a buffer. A user might expect to get the same type out again, but gets bytes instead.
* Strided data is still copied.
* No test cases yet. Might needs some more type checks.