### PR TITLE
Add sort_keys parameter to Packer for stable dict packing.

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -609,12 +609,16 @@ class Packer(object):
     :param bool use_bin_type:
         Use bin type introduced in msgpack spec 2.0 for bytes.
         It also enable str8 type for unicode.
+    :param bool sort_keys:
+        Sort output dictionaries by key. (default: False)
     """
     def __init__(self, default=None, encoding='utf-8', unicode_errors='strict',
-                 use_single_float=False, autoreset=True, use_bin_type=False):
+                 use_single_float=False, autoreset=True, use_bin_type=False,
+                 sort_keys=False):
         self._use_float = use_single_float
         self._autoreset = autoreset
         self._use_bin_type = use_bin_type
+        self._sort_keys = sort_keys
         self._encoding = encoding
         self._unicode_errors = unicode_errors
         self._buffer = StringIO()
@@ -726,8 +730,11 @@ class Packer(object):
                     self._pack(obj[i], nest_limit - 1)
                 return
             if isinstance(obj, dict):
-                return self._fb_pack_map_pairs(len(obj), dict_iteritems(obj),
-                                               nest_limit - 1)
+                if self._sort_keys:
+                    pairs = sorted(dict_iteritems(obj))
+                else:
+                    pairs = dict_iteritems(obj)
+                return self._fb_pack_map_pairs(len(obj), pairs, nest_limit - 1)
             if not default_used and self._default is not None:
                 obj = self._default(obj)
                 default_used = 1

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -128,6 +128,12 @@ def testMapSize(sizes=[0, 5, 50, 1000]):
     for size in sizes:
         assert unpacker.unpack() == dict((i, i * 2) for i in range(size))
 
+def testSortKeys(sizes=[3, 31, 127, 1023]):
+    for size in sizes:
+        keys = range(1, 1000000000, 1000000000 // size)
+        map1 = {k: k for k in keys}
+        map2 = {k: k for k in reversed(keys)}
+        assert packb(map1, sort_keys=True) == packb(map2, sort_keys=True)
 
 class odict(dict):
     '''Reimplement OrderedDict to run test on Python 2.6'''


### PR DESCRIPTION
It is often useful to have reproducible serialization. It allows, for instance, efficient comparison of records coming from different sources.

simplejson provides an option sort_keys, which makes serialization of dictionaries reproducible. This patch adds the same option to msgpack Packer class.