### PR TITLE
Fix problems associated with packing memoryviews

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -685,58 +685,29 @@ class Packer(object):
                     default_used = True
                     continue
                 raise PackOverflowError("Integer value out of range")
-            if self._use_bin_type and check(obj, bytes):
+            if check(obj, bytes):
                 n = len(obj)
-                if n <= 0xff:
-                    self._buffer.write(struct.pack('>BB', 0xc4, n))
-                elif n <= 0xffff:
-                    self._buffer.write(struct.pack(">BH", 0xc5, n))
-                elif n <= 0xffffffff:
-                    self._buffer.write(struct.pack(">BI", 0xc6, n))
-                else:
+                if n >= 2**32:
                     raise PackValueError("Bytes is too large")
+                self._fb_pack_bin_header(n)
                 return self._buffer.write(obj)
-            if check(obj, (Unicode, bytes)):
-                if check(obj, Unicode):
-                    if self._encoding is None:
-                        raise TypeError(
-                            "Can't encode unicode string: "
-                            "no encoding is specified")
-                    obj = obj.encode(self._encoding, self._unicode_errors)
+            if check(obj, Unicode):
+                if self._encoding is None:
+                    raise TypeError(
+                        "Can't encode unicode string: "
+                        "no encoding is specified")
+                obj = obj.encode(self._encoding, self._unicode_errors)
                 n = len(obj)
-                if n <= 0x1f:
-                    self._buffer.write(struct.pack('B', 0xa0 + n))
-                elif self._use_bin_type and n <= 0xff:
-                    self._buffer.write(struct.pack('>BB', 0xd9, n))
-                elif n <= 0xffff:
-                    self._buffer.write(struct.pack(">BH", 0xda, n))
-                elif n <= 0xffffffff:
-                    self._buffer.write(struct.pack(">BI", 0xdb, n))
-                else:
+                if n >= 2**32:
                     raise PackValueError("String is too large")
+                self._fb_pack_raw_header(n)
                 return self._buffer.write(obj)
             if check(obj, memoryview):
                 n = len(obj) * obj.itemsize
-                if self._use_bin_type:
-                    if n <= 0xff:
-                        self._buffer.write(struct.pack('>BB', 0xc4, n))
-                    elif n <= 0xffff:
-                        self._buffer.write(struct.pack(">BH", 0xc5, n))
-                    elif n <= 0xffffffff:
-                        self._buffer.write(struct.pack(">BI", 0xc6, n))
-                    else:
-                        raise PackValueError("memoryview is too large")
-                    return self._buffer.write(obj)
-                else:
-                    if n <= 0x1f:
-                        self._buffer.write(struct.pack('B', 0xa0 + n))
-                    elif n <= 0xffff:
-                        self._buffer.write(struct.pack(">BH", 0xda, n))
-                    elif n <= 0xffffffff:
-                        self._buffer.write(struct.pack(">BI", 0xdb, n))
-                    else:
-                        raise PackValueError("memoryview is too large")
-                    return self._buffer.write(obj)
+                if n >= 2**32:
+                    raise PackValueError("Memoryview is too large")
+                self._fb_pack_bin_header(n)
+                return self._buffer.write(obj)
             if check(obj, float):
                 if self._use_float:
                     return self._buffer.write(struct.pack(">Bf", 0xca, obj))
@@ -873,6 +844,30 @@ class Packer(object):
         for (k, v) in pairs:
             self._pack(k, nest_limit - 1)
             self._pack(v, nest_limit - 1)
+
+    def _fb_pack_raw_header(self, n):
+        if n <= 0x1f:
+            self._buffer.write(struct.pack('B', 0xa0 + n))
+        elif self._use_bin_type and n <= 0xff:
+            self._buffer.write(struct.pack('>BB', 0xd9, n))
+        elif n <= 0xffff:
+            self._buffer.write(struct.pack(">BH", 0xda, n))
+        elif n <= 0xffffffff:
+            self._buffer.write(struct.pack(">BI", 0xdb, n))
+        else:
+            raise PackValueError('Raw is too large')
+
+    def _fb_pack_bin_header(self, n):
+        if not self._use_bin_type:
+            return self._fb_pack_raw_header(n)
+        elif n <= 0xff:
+            return self._buffer.write(struct.pack('>BB', 0xc4, n))
+        elif n <= 0xffff:
+            return self._buffer.write(struct.pack(">BH", 0xc5, n))
+        elif n <= 0xffffffff:
+            return self._buffer.write(struct.pack(">BI", 0xc6, n))
+        else:
+            raise PackValueError('Bin is too large')
 
     def bytes(self):
         return self._buffer.getvalue()

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -11,25 +11,25 @@ import sys
 #  - array type only supports old buffer interface
 #  - array.frombytes is not available, must use deprecated array.fromstring
 if sys.version_info[0] < 3:
-    def __memoryview(obj):
+    def make_memoryview(obj):
         return memoryview(buffer(obj))
 
-    def __make_array(f, data):
+    def make_array(f, data):
         a = array(f)
         a.fromstring(data)
         return a
 
-    def __get_data(a):
+    def get_data(a):
         return a.tostring()
 else:
-    __memoryview = memoryview
+    make_memoryview = memoryview
 
-    def __make_array(f, data):
+    def make_array(f, data):
         a = array(f)
         a.frombytes(data)
         return a
 
-    def __get_data(a):
+    def get_data(a):
         return a.tobytes()
 
 
@@ -37,13 +37,13 @@ def __run_test(format, nbytes, expected_header, expected_prefix, use_bin_type):
     # create a new array
     original_array = array(format)
     original_array.fromlist([255] * (nbytes // original_array.itemsize))
-    original_data = __get_data(original_array)
-    view = __memoryview(original_array)
+    original_data = get_data(original_array)
+    view = make_memoryview(original_array)
 
     # pack, unpack, and reconstruct array
     packed = packb(view, use_bin_type=use_bin_type)
     unpacked = unpackb(packed)
-    reconstructed_array = __make_array(format, unpacked)
+    reconstructed_array = make_array(format, unpacked)
 
     # check that we got the right amount of data
     assert len(original_data) == nbytes
@@ -57,79 +57,49 @@ def __run_test(format, nbytes, expected_header, expected_prefix, use_bin_type):
     assert original_array == reconstructed_array
 
 
-# -----------
-# test fixstr
-# -----------
-
-
-def test_memoryview_byte_fixstr():
+def test_fixstr_from_byte():
     __run_test('B', 31, b'\xbf', b'', False)
 
 
-def test_memoryview_float_fixstr():
+def test_fixstr_from_float():
     __run_test('f', 28, b'\xbc', b'', False)
 
 
-# ----------
-# test str16
-# ----------
-
-
-def test_memoryview_byte_str16():
+def test_str16_from_byte():
     __run_test('B', 2**8, b'\xda', b'\x01\x00', False)
 
 
-def test_memoryview_float_str16():
+def test_str16_from_float():
     __run_test('f', 2**8, b'\xda', b'\x01\x00', False)
 
 
-# ----------
-# test str32
-# ----------
-
-
-def test_memoryview_byte_str32():
+def test_str32_from_byte():
     __run_test('B', 2**16, b'\xdb', b'\x00\x01\x00\x00', False)
 
 
-def test_memoryview_float_str32():
+def test_str32_from_float():
     __run_test('f', 2**16, b'\xdb', b'\x00\x01\x00\x00', False)
 
 
-# ---------
-# test bin8
-# ---------
-
-
-def test_memoryview_byte_bin8():
+def test_bin8_from_byte():
     __run_test('B', 1, b'\xc4', b'\x01', True)
 
 
-def test_memoryview_float_bin8():
+def test_bin8_from_float():
     __run_test('f', 4, b'\xc4', b'\x04', True)
 
 
-# ----------
-# test bin16
-# ----------
-
-
-def test_memoryview_byte_bin16():
+def test_bin16_from_byte():
     __run_test('B', 2**8, b'\xc5', b'\x01\x00', True)
 
 
-def test_memoryview_float_bin16():
+def test_bin16_from_float():
     __run_test('f', 2**8, b'\xc5', b'\x01\x00', True)
 
 
-# ----------
-# test bin32
-# ----------
-
-
-def test_memoryview_byte_bin32():
+def test_bin32_from_byte():
     __run_test('B', 2**16, b'\xc6', b'\x00\x01\x00\x00', True)
 
 
-def test_memoryview_float_bin32():
+def test_bin32_from_float():
     __run_test('f', 2**16, b'\xc6', b'\x00\x01\x00\x00', True)

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -58,19 +58,23 @@ def __run_test(format, nbytes, expected_header, expected_prefix, use_bin_type):
 
 
 def test_fixstr_from_byte():
+    __run_test('B', 1, b'\xa1', b'', False)
     __run_test('B', 31, b'\xbf', b'', False)
 
 
 def test_fixstr_from_float():
+    __run_test('f', 4, b'\xa4', b'', False)
     __run_test('f', 28, b'\xbc', b'', False)
 
 
 def test_str16_from_byte():
     __run_test('B', 2**8, b'\xda', b'\x01\x00', False)
+    __run_test('B', 2**16-1, b'\xda', b'\xff\xff', False)
 
 
 def test_str16_from_float():
     __run_test('f', 2**8, b'\xda', b'\x01\x00', False)
+    __run_test('f', 2**16-4, b'\xda', b'\xff\xfc', False)
 
 
 def test_str32_from_byte():
@@ -83,18 +87,22 @@ def test_str32_from_float():
 
 def test_bin8_from_byte():
     __run_test('B', 1, b'\xc4', b'\x01', True)
+    __run_test('B', 2**8-1, b'\xc4', b'\xff', True)
 
 
 def test_bin8_from_float():
     __run_test('f', 4, b'\xc4', b'\x04', True)
+    __run_test('f', 2**8-4, b'\xc4', b'\xfc', True)
 
 
 def test_bin16_from_byte():
     __run_test('B', 2**8, b'\xc5', b'\x01\x00', True)
+    __run_test('B', 2**16-1, b'\xc5', b'\xff\xff', True)
 
 
 def test_bin16_from_float():
     __run_test('f', 2**8, b'\xc5', b'\x01\x00', True)
+    __run_test('f', 2**16-4, b'\xc5', b'\xff\xfc', True)
 
 
 def test_bin32_from_byte():

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -2,11 +2,134 @@
 # coding: utf-8
 
 
+from array import array
 from msgpack import packb, unpackb
+import sys
 
 
-def test_pack_memoryview():
-    data = bytearray(range(256))
-    view = memoryview(data)
-    unpacked = unpackb(packb(view))
-    assert data == unpacked
+# For Python < 3:
+#  - array type only supports old buffer interface
+#  - array.frombytes is not available, must use deprecated array.fromstring
+if sys.version_info[0] < 3:
+    def __memoryview(obj):
+        return memoryview(buffer(obj))
+
+    def __make_array(f, data):
+        a = array(f)
+        a.fromstring(data)
+        return a
+
+    def __get_data(a):
+        return a.tostring()
+else:
+    __memoryview = memoryview
+
+    def __make_array(f, data):
+        a = array(f)
+        a.frombytes(data)
+        return a
+
+    def __get_data(a):
+        return a.tobytes()
+
+
+def __run_test(format, nbytes, expected_header, expected_prefix, use_bin_type):
+    # create a new array
+    original_array = array(format)
+    original_array.fromlist([255] * (nbytes // original_array.itemsize))
+    original_data = __get_data(original_array)
+    view = __memoryview(original_array)
+
+    # pack, unpack, and reconstruct array
+    packed = packb(view, use_bin_type=use_bin_type)
+    unpacked = unpackb(packed)
+    reconstructed_array = __make_array(format, unpacked)
+
+    # check that we got the right amount of data
+    assert len(original_data) == nbytes
+    # check packed header
+    assert packed[:1] == expected_header
+    # check packed length prefix, if any
+    assert packed[1:1+len(expected_prefix)] == expected_prefix
+    # check packed data
+    assert packed[1+len(expected_prefix):] == original_data
+    # check array unpacked correctly
+    assert original_array == reconstructed_array
+
+
+# -----------
+# test fixstr
+# -----------
+
+
+def test_memoryview_byte_fixstr():
+    __run_test('B', 31, b'\xbf', b'', False)
+
+
+def test_memoryview_float_fixstr():
+    __run_test('f', 28, b'\xbc', b'', False)
+
+
+# ----------
+# test str16
+# ----------
+
+
+def test_memoryview_byte_str16():
+    __run_test('B', 2**8, b'\xda', b'\x01\x00', False)
+
+
+def test_memoryview_float_str16():
+    __run_test('f', 2**8, b'\xda', b'\x01\x00', False)
+
+
+# ----------
+# test str32
+# ----------
+
+
+def test_memoryview_byte_str32():
+    __run_test('B', 2**16, b'\xdb', b'\x00\x01\x00\x00', False)
+
+
+def test_memoryview_float_str32():
+    __run_test('f', 2**16, b'\xdb', b'\x00\x01\x00\x00', False)
+
+
+# ---------
+# test bin8
+# ---------
+
+
+def test_memoryview_byte_bin8():
+    __run_test('B', 1, b'\xc4', b'\x01', True)
+
+
+def test_memoryview_float_bin8():
+    __run_test('f', 4, b'\xc4', b'\x04', True)
+
+
+# ----------
+# test bin16
+# ----------
+
+
+def test_memoryview_byte_bin16():
+    __run_test('B', 2**8, b'\xc5', b'\x01\x00', True)
+
+
+def test_memoryview_float_bin16():
+    __run_test('f', 2**8, b'\xc5', b'\x01\x00', True)
+
+
+# ----------
+# test bin32
+# ----------
+
+
+def test_memoryview_byte_bin32():
+    __run_test('B', 2**16, b'\xc6', b'\x00\x01\x00\x00', True)
+
+
+def test_memoryview_float_bin32():
+    __run_test('f', 2**16, b'\xc6', b'\x00\x01\x00\x00', True)


### PR DESCRIPTION
Hi,

This PR addresses issues pointed out in https://github.com/msgpack/msgpack-python/issues/126#issuecomment-214425711

- The pure python fallback used the length, not the number of bytes of a memoryview. Views with multi-byte types would be prefixed with a fraction of their real length.
- Packing without ``use_bin_type=True`` and unpacking with encoding set leads to errors. ``use_bin_type=True`` is now enforced for memoryviews to avoid this.
- Add some tests that pack/unpack memoryviews of different types and sizes.