### PR TITLE
Use new buffer interface to unpack

### DIFF
--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -18,3 +18,12 @@ def test_unpack_bytearray():
     assert [b'foo', b'bar'] == obj
     expected_type = bytes
     assert all(type(s) == expected_type for s in obj)
+
+
+def test_unpack_memoryview():
+    buf = bytearray(packb(('foo', 'bar')))
+    view = memoryview(buf)
+    obj = unpackb(view, use_list=1)
+    assert [b'foo', b'bar'] == obj
+    expected_type = bytes
+    assert all(type(s) == expected_type for s in obj)


### PR DESCRIPTION
This PR adds support for unpacking/feeding from any object that supports the new buffer interface.

For compatibility, an attempt is made to use the old buffer interface if that fails. On success, a ``RuntimeWarning`` is issued to inform users of possible errors and future removal of this feature.