### PR TITLE
fix typos and other cosmetic issues

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -160,7 +160,7 @@ Changes
 
 
 0.2.4
-=======
+=====
 :release date: 2012-12-22
 
 Bugs fixed
@@ -169,7 +169,7 @@ Bugs fixed
 * Fix SEGV when object_hook or object_pairs_hook raise Exception. (#39)
 
 0.2.3
-=======
+=====
 :release date: 2012-12-11
 
 Changes
@@ -177,11 +177,11 @@ Changes
 * Warn when use_list is not specified. It's default value will be changed in 0.3.
 
 Bugs fixed
------------
+----------
 * Can't pack subclass of dict.
 
 0.2.2
-=======
+=====
 :release date: 2012-09-21
 
 Changes
@@ -190,7 +190,7 @@ Changes
   object in single precision format.
 
 Bugs fixed
------------
+----------
 * ``unpack()`` didn't restores gc state when it called with gc disabled.
   ``unpack()`` doesn't control gc now instead of restoring gc state collectly.
   User can control gc state when gc cause performance issue.
@@ -198,7 +198,7 @@ Bugs fixed
 * ``Unpacker``'s ``read_size`` option didn't used.
 
 0.2.1
-=======
+=====
 :release date: 2012-08-20
 
 Changes
@@ -206,8 +206,8 @@ Changes
 * Add ``max_buffer_size`` parameter to Unpacker. It limits internal buffer size
   and allows unpack data from untrusted source safely.
 
-* Unpacker's buffer reallocation algorithm is less greedy now. It cause perforamce
-  derease in rare case but memory efficient and don't allocate than ``max_buffer_size``.
+* Unpacker's buffer reallocation algorithm is less greedy now. It cause performance
+  decrease in rare case but memory efficient and don't allocate than ``max_buffer_size``.
 
 Bugs fixed
 ----------
@@ -217,7 +217,7 @@ Bugs fixed
 
 
 0.2.0
-=======
+=====
 :release date: 2012-06-27
 
 Changes
@@ -232,16 +232,16 @@ Bugs fixed
 
 
 0.1.13
-=======
+======
 :release date: 2012-04-21
 
 New
-----
+---
 * Don't accept subtype of list and tuple as msgpack list. (Steeve Morin)
   It allows customize how it serialized with ``default`` argument.
 
 Bugs fixed
------------
+----------
 * Fix wrong error message. (David Wolever)
 * Fix memory leak while unpacking when ``object_hook`` or ``list_hook`` is used.
   (Steeve Morin)
@@ -253,21 +253,21 @@ Other changes
 
 
 0.1.12
-=======
+======
 :release date: 2011-12-27
 
 Bugs fixed
--------------
+----------
 
 * Re-enable packs/unpacks removed at 0.1.11. It will be removed when 0.2 is released.
 
 
 0.1.11
-=======
+======
 :release date: 2011-12-26
 
 Bugs fixed
--------------
+----------
 
 * Include test code for Python3 to sdist. (Johan Bergström)
 * Fix compilation error on MSVC. (davidgaleano)
@@ -285,7 +285,7 @@ New feature
 
 
 0.1.9
-======
+=====
 :release date: 2011-01-29
 
 New feature
@@ -299,16 +299,16 @@ Bugs fixed
 * Add MemoryError check.
 
 0.1.8
-======
+=====
 :release date: 2011-01-10
 
 New feature
-------------
+-----------
 * Support ``loads`` and ``dumps`` aliases for API compatibility with
   simplejson and pickle.
 
 * Add *object_hook* and *list_hook* option to unpacker. It allows you to
-  hook unpacing mapping type and array type.
+  hook unpacking mapping type and array type.
 
 * Add *default* option to packer. It allows you to pack unsupported types.
 
@@ -320,13 +320,13 @@ Bugs fixed
 
 
 0.1.7
-======
+=====
 :release date: 2010-11-02
 
 New feature
-------------
+-----------
 * Add *object_hook* and *list_hook* option to unpacker. It allows you to
-  hook unpacing mapping type and array type.
+  hook unpacking mapping type and array type.
 
 * Add *default* option to packer. It allows you to pack unsupported types.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=======================
+======================
 MessagePack for Python
-=======================
+======================
 
 :author: INADA Naoki
 :version: 0.4.6
@@ -11,21 +11,22 @@ MessagePack for Python
    
 
 What's this
-------------
+-----------
 
-`MessagePack <http://msgpack.org/>`_ is a fast, compact binary serialization format, suitable for
-similar data to JSON. This package provides CPython bindings for reading and
-writing MessagePack data.
+`MessagePack <http://msgpack.org/>`_ is an efficient binary serialization format.
+It lets you exchange data among multiple languages like JSON.
+But it's faster and smaller.
+This package provides CPython bindings for reading and writing MessagePack data.
 
 Install
----------
+-------
 
 ::
 
    $ pip install msgpack-python
 
 PyPy
-^^^^^
+^^^^
 
 msgpack-python provides pure python implementation.  PyPy can use this.
 
@@ -44,7 +45,7 @@ Community Edition or Express Edition can be used to build extension module.
 
 
 How to use
------------
+----------
 
 One-shot pack & unpack
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -134,7 +135,7 @@ It is also possible to pack/unpack custom data types. Here is an example for
 key-value pairs.
 
 Extended types
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 It is also possible to pack/unpack custom data types using the **ext** type.
 
@@ -166,7 +167,7 @@ Advanced unpacking control
 
 As an alternative to iteration, ``Unpacker`` objects provide ``unpack``,
 ``skip``, ``read_array_header`` and ``read_map_header`` methods. The former two
-read an entire message from the stream, respectively deserialising and returning
+read an entire message from the stream, respectively de-serialising and returning
 the result, or ignoring it. The latter two methods return the number of elements
 in the upcoming container, so that each element in an array, or key-value pair
 in a map, can be unpacked or skipped individually.
@@ -243,7 +244,7 @@ instead of `StopIteration`.
 `StopIteration` is used for iterator protocol only.
 
 Note about performance
-------------------------
+----------------------
 
 GC
 ^^
@@ -253,7 +254,7 @@ This means unpacking may cause useless GC.
 You can use ``gc.disable()`` when unpacking large message.
 
 use_list option
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 List is the default sequence type of Python.
 But tuple is lighter than list.
 You can use ``use_list=False`` while unpacking when performance is important.
@@ -264,7 +265,7 @@ Another way to unpacking such object is using ``object_pairs_hook``.
 
 
 Development
-------------
+-----------
 
 Test
 ^^^^

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ test_script:
   # only needed to support those cases.
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
-  # to put the Python evrsion you want to use on PATH.
+  # to put the Python version you want to use on PATH.
   - "build.cmd %PYTHON%\\python.exe setup.py build_ext -i"
   - "build.cmd %PYTHON%\\python.exe setup.py install"
   - "%PYTHON%\\python.exe -c \"import sys; print(hex(sys.maxsize))\""

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,7 @@ API reference
 .. autoclass:: ExtType
 
 exceptions
------------
+----------
 
 These exceptions are accessible via `msgpack` package.
 (For example, `msgpack.OutOfData` is shortcut for `msgpack.exceptions.OutOfData`)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 msgpack document
-==================
+================
 
 `MessagePack <http://msgpack.org>`_ is a efficient format for inter
 language data exchange.

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -58,11 +58,11 @@ cdef class Packer(object):
     :param bool use_single_float:
         Use single precision float type for float. (default: False)
     :param bool autoreset:
-        Reset buffer after each pack and return it's content as `bytes`. (default: True).
+        Reset buffer after each pack and return its content as `bytes`. (default: True).
         If set this to false, use `bytes()` to get content and `.reset()` to clear buffer.
     :param bool use_bin_type:
         Use bin type introduced in msgpack spec 2.0 for bytes.
-        It also enable str8 type for unicode.
+        It also enables str8 type for unicode.
     """
     cdef msgpack_packer pk
     cdef object _default
@@ -75,7 +75,7 @@ cdef class Packer(object):
 
     def __cinit__(self):
         cdef int buf_size = 1024*1024
-        self.pk.buf = <char*> malloc(buf_size);
+        self.pk.buf = <char*> malloc(buf_size)
         if self.pk.buf == NULL:
             raise MemoryError("Unable to allocate internal buffer.")
         self.pk.buf_size = buf_size
@@ -108,7 +108,7 @@ cdef class Packer(object):
             self.unicode_errors = PyBytes_AsString(self._berrors)
 
     def __dealloc__(self):
-        free(self.pk.buf);
+        free(self.pk.buf)
 
     cdef int _pack(self, object o, int nest_limit=DEFAULT_RECURSE_LIMIT) except -1:
         cdef long long llval
@@ -274,7 +274,7 @@ cdef class Packer(object):
         """
         Pack *pairs* as msgpack map type.
 
-        *pairs* should sequence of pair.
+        *pairs* should be a sequence of pairs.
         (`len(pairs)` and `for k, v in pairs:` should be supported.)
         """
         cdef int ret = msgpack_pack_map(&self.pk, len(pairs))

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -209,7 +209,7 @@ cdef class Unpacker(object):
     :param int max_buffer_size:
         Limits size of data waiting unpacked.  0 means system's INT_MAX (default).
         Raises `BufferFull` exception when it is insufficient.
-        You shoud set this parameter when unpacking data from untrusted source.
+        You should set this parameter when unpacking data from untrusted source.
 
     :param int max_str_len:
         Limits max length of str. (default: 2**31-1)

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -138,7 +138,7 @@ class Unpacker(object):
     :param int max_buffer_size:
         Limits size of data waiting unpacked.  0 means system's INT_MAX (default).
         Raises `BufferFull` exception when it is insufficient.
-        You shoud set this parameter when unpacking data from untrusted source.
+        You should set this parameter when unpacking data from untrusted source.
 
     :param int max_str_len:
         Limits max length of str. (default: 2**31-1)
@@ -188,13 +188,13 @@ class Unpacker(object):
             self.file_like = file_like
             self._fb_feeding = False
 
-        #: array of bytes feeded.
+        #: array of bytes fed.
         self._fb_buffers = []
         #: Which buffer we currently reads
         self._fb_buf_i = 0
         #: Which position we currently reads
         self._fb_buf_o = 0
-        #: Total size of _fb_bufferes
+        #: Total size of _fb_buffers
         self._fb_buf_n = 0
 
         # When Unpacker is used as an iterable, between the calls to next(),
@@ -203,7 +203,7 @@ class Unpacker(object):
         # the correct moments, we have to keep track of how sloppy we were.
         # Furthermore, when the buffer is incomplete (that is: in the case
         # we raise an OutOfData) we need to rollback the buffer to the correct
-        # state, which _fb_slopiness records.
+        # state, which _fb_sloppiness records.
         self._fb_sloppiness = 0
 
         self._max_buffer_size = max_buffer_size or 2**31-1
@@ -303,7 +303,7 @@ class Unpacker(object):
 
     def _fb_read(self, n, write_bytes=None):
         buffs = self._fb_buffers
-        # We have a redundant codepath for the most common case, such that
+        # We have a redundant code path for the most common case, such that
         # pypy optimizes it properly.  This is the case that the read fits
         # in the current buffer.
         if (write_bytes is None and self._fb_buf_i < len(buffs) and
@@ -598,17 +598,17 @@ class Packer(object):
         Convert user type to builtin type that Packer supports.
         See also simplejson's document.
     :param str encoding:
-            Convert unicode to bytes with this encoding. (default: 'utf-8')
+        Convert unicode to bytes with this encoding. (default: 'utf-8')
     :param str unicode_errors:
         Error handler for encoding unicode. (default: 'strict')
     :param bool use_single_float:
         Use single precision float type for float. (default: False)
     :param bool autoreset:
-        Reset buffer after each pack and return it's content as `bytes`. (default: True).
+        Reset buffer after each pack and return its content as `bytes`. (default: True).
         If set this to false, use `bytes()` to get content and `.reset()` to clear buffer.
     :param bool use_bin_type:
         Use bin type introduced in msgpack spec 2.0 for bytes.
-        It also enable str8 type for unicode.
+        It also enables str8 type for unicode.
     """
     def __init__(self, default=None, encoding='utf-8', unicode_errors='strict',
                  use_single_float=False, autoreset=True, use_bin_type=False):

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -42,7 +42,7 @@ def test_extension_type():
             typecode = 123 # application specific typecode
             data = obj.tostring()
             return ExtType(typecode, data)
-        raise TypeError("Unknwon type object %r" % (obj,))
+        raise TypeError("Unknown type object %r" % (obj,))
 
     def ext_hook(code, data):
         print('ext_hook called', code, data)

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -130,7 +130,7 @@ def testMapSize(sizes=[0, 5, 50, 1000]):
 
 
 class odict(dict):
-    '''Reimplement OrderedDict to run test on Python 2.6'''
+    """Reimplement OrderedDict to run test on Python 2.6"""
     def __init__(self, seq):
         self._seq = seq
         dict.__init__(self, seq)


### PR DESCRIPTION
cosmetic issues:
- reST headlines' underline length needs to match the headline length
  (looks like somebody is / was using a proportional font)
- Cython code lines do not need to be terminated with a semicolon
- always use triple-double-quotes for docstrings

I did the PR against release-0.4 branch, hope this is correct to get it fixed in next release and also get it merged from there into master.