### PR TITLE
packer: add passthrough for already packed data

### DIFF
--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -17,6 +17,15 @@ class ExtType(namedtuple('ExtType', 'code data')):
         return super(ExtType, cls).__new__(cls, code, data)
 
 
+class Passthrough(object):
+    """Class to pass raw msgpack data into a packer."""
+    def __init__(self, data):
+        self.data = data
+
+    def __bytes__(self):
+        return self.data
+
+
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):
     from msgpack.fallback import Packer, unpack, unpackb, Unpacker

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -4,7 +4,7 @@
 from cpython cimport *
 
 from msgpack.exceptions import PackValueError, PackOverflowError
-from msgpack import ExtType
+from msgpack import ExtType, Passthrough
 
 
 cdef extern from "Python.h":
@@ -34,6 +34,7 @@ cdef extern from "pack.h":
     int msgpack_pack_bin(msgpack_packer* pk, size_t l)
     int msgpack_pack_raw_body(msgpack_packer* pk, char* body, size_t l)
     int msgpack_pack_ext(msgpack_packer* pk, char typecode, size_t l)
+    int msgpack_pack_write(msgpack_packer* pk, const char *data, size_t l)
 
 cdef int DEFAULT_RECURSE_LIMIT=511
 cdef size_t ITEM_LIMIT = (2**32)-1
@@ -53,7 +54,7 @@ cdef class Packer(object):
 
     :param callable default:
         Convert user type to builtin type that Packer supports.
-        See also simplejson's document.
+        See also simplejson's documentation.
     :param str encoding:
         Convert unicode to bytes with this encoding. (default: 'utf-8')
     :param str unicode_errors:
@@ -73,6 +74,10 @@ cdef class Packer(object):
         Additionally tuples will not be serialized as lists.
         This is useful when trying to implement accurate serialization
         for python types.
+    :param class passthrough:
+        Class used for data passthrough. Instances are expected to implement the `__bytes__`
+        protocol. Returned data is written directly to output with no conversion or wrapping,
+        so it has to be a valid msgpack object. A sample class is supplied in `msgpack.Passthrough`.
     """
     cdef msgpack_packer pk
     cdef object _default
@@ -83,6 +88,7 @@ cdef class Packer(object):
     cdef bint strict_types
     cdef bool use_float
     cdef bint autoreset
+    cdef object _passthrough
 
     def __cinit__(self):
         cdef int buf_size = 1024*1024
@@ -94,7 +100,7 @@ cdef class Packer(object):
 
     def __init__(self, default=None, encoding='utf-8', unicode_errors='strict',
                  use_single_float=False, bint autoreset=1, bint use_bin_type=0,
-                 bint strict_types=0):
+                 bint strict_types=0, passthrough=None):
         self.use_float = use_single_float
         self.strict_types = strict_types
         self.autoreset = autoreset
@@ -103,6 +109,10 @@ cdef class Packer(object):
             if not PyCallable_Check(default):
                 raise TypeError("default must be a callable.")
         self._default = default
+        if passthrough is not None:
+            if not PyType_Check(passthrough):
+                raise TypeError("passthrough must be a class.")
+        self._passthrough = passthrough
         if encoding is None:
             self.encoding = NULL
             self.unicode_errors = NULL
@@ -245,6 +255,14 @@ cdef class Packer(object):
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, <char*>view.buf, L)
                 PyBuffer_Release(&view);
+            elif self._passthrough is not None and isinstance(o, self._passthrough):
+                # Use the __bytes__ protocol directly as specified above.
+                # Compared to bytes(o) this is portable to Python 2, and does
+                # not incur an additional copy.
+                if PyObject_GetBuffer(o.__bytes__(), &view, PyBUF_SIMPLE) != 0:
+                    raise PackValueError("could not get buffer")
+                ret = msgpack_pack_write(&self.pk, <char*>view.buf, view.len)
+                PyBuffer_Release(&view)
             elif not default_used and self._default:
                 o = self._default(o)
                 default_used = 1

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import struct
 from pytest import raises, xfail
 
-from msgpack import packb, unpackb, Unpacker, Packer
+from msgpack import packb, unpackb, Unpacker, Packer, Passthrough
 
 from io import BytesIO
 
@@ -159,3 +159,19 @@ def test_pairlist():
     packed = packer.pack_map_pairs(pairlist)
     unpacked = unpackb(packed, object_pairs_hook=list)
     assert pairlist == unpacked
+
+
+def test_passthrough():
+    map = {1: Passthrough(b'\x93\xa3foo\xa3bar\xa3baz')}
+    packed = packb(map, passthrough=Passthrough)
+    assert packed == b'\x81\x01' + b'\x93\xa3foo\xa3bar\xa3baz'
+    unpacked = unpackb(packed)
+    assert unpacked == {1: [b'foo', b'bar', b'baz']}
+
+
+def test_passthrough_trailing():
+    listing = [b'foo', Passthrough(b'\xa3bar'), b'baz']
+    packed = packb(listing, passthrough=Passthrough)
+    assert packed == b'\x93\xa3foo\xa3bar\xa3baz'
+    unpacked = unpackb(packed)
+    assert unpacked == [b'foo', b'bar', b'baz']


### PR DESCRIPTION
This patch adds a Packer option to allow already msgpacked data as an object. Such data is copied verbatim into the output buffer (=passthrough).

This helps when the application has some (possibly large or complex) msgpack structure it wants to embed in another msgpack structure. Without this patch it has to unpack it first and then repack it again. That is no good for throughput and requires a lot of copies and CPU. 

