### PR TITLE
Add pyxbld files so you can do testing much more easily.

### DIFF
--- a/msgpack/_packer.pyxbld
+++ b/msgpack/_packer.pyxbld
@@ -1,0 +1,41 @@
+
+import os.path
+import sys
+
+def make_ext(modname, pyxfilename):
+	from distutils.extension import Extension
+
+	if sys.byteorder == 'big':
+		macros = [('__BIG_ENDIAN__', '1')]
+	else:
+		macros = [('__LITTLE_ENDIAN__', '1')]
+
+	ret = Extension(name=modname,
+					sources=[
+							pyxfilename,
+						],
+					libraries=[
+						],
+					include_dirs = [
+							'.',
+							'./msgpack/',
+						],
+					language='C++',
+					extra_compile_args=[
+						"-march=native",
+						"-mtune=native",
+						"-O3",
+						],
+					extra_link_args=[
+						"-march=native",
+						"-mtune=native",
+						"-O3",
+						],
+						define_macros=macros,
+					)
+
+	return ret
+
+
+def make_setup_args():
+	return dict(script_args=['--verbose'])

--- a/msgpack/_unpacker.pyxbld
+++ b/msgpack/_unpacker.pyxbld
@@ -1,0 +1,42 @@
+
+import os.path
+import sys
+
+def make_ext(modname, pyxfilename):
+	from distutils.extension import Extension
+
+	if sys.byteorder == 'big':
+		macros = [('__BIG_ENDIAN__', '1')]
+	else:
+		macros = [('__LITTLE_ENDIAN__', '1')]
+
+	ret = Extension(name=modname,
+					sources=[
+							pyxfilename,
+						],
+					libraries=[
+						],
+					include_dirs = [
+							'.',
+							'./msgpack/',
+						],
+					language='C++',
+					extra_compile_args=[
+						"-march=native",
+						"-mtune=native",
+						"-O3",
+						],
+					extra_link_args=[
+						"-march=native",
+						"-mtune=native",
+						"-O3",
+						],
+						define_macros=macros,
+					)
+
+	return ret
+
+
+def make_setup_args():
+	return dict(script_args=['--verbose'])
+


### PR DESCRIPTION
This PR adds `.pyxbld` files for the two cython files, which allows their use via Cython's [`pyximport()`](https://github.com/cython/cython/tree/master/pyximport) interface.

This is principally useful for testing/development, but since the pyxbld files aren't bundled when building a proper release, it's harmless in all other cases.

Principally, this means you can use test-scripts like:

```

import pyximport
pyximport.install()

import os
print("Importing msgpack")
import msgpack
print("Imported")

data = os.urandom(1024 * 1024) * 375
print("Data generated. Packing", len(data))
message_bytes = msgpack.packb(data, use_bin_type=True)
print("Packed", len(message_bytes))

```

Assuming the `msgpack` dir is in the same folder as the above script, the two `*.pyx` files are automatically compiled at import-time, leading to much faster test cycles.