### PR TITLE
Fix unicode_errors encoding

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -127,27 +127,26 @@ cdef class Packer(object):
             if not PyCallable_Check(default):
                 raise TypeError("default must be a callable.")
         self._default = default
-        if encoding is None:
-            if unicode_errors is None:
-                self.encoding = NULL
-                self.unicode_errors = NULL
-            else:
-                self.encoding = "utf_8"
-                self.unicode_errors = unicode_errors
+        if encoding is None and unicode_errors is None:
+            self.encoding = NULL
+            self.unicode_errors = NULL
         else:
-            if isinstance(encoding, unicode):
-                self._bencoding = encoding.encode('ascii')
+            if encoding is None:
+                self.encoding = 'utf-8'
             else:
-                self._bencoding = encoding
-            self.encoding = PyBytes_AsString(self._bencoding)
-            if isinstance(unicode_errors, unicode):
-                self._berrors = unicode_errors.encode('ascii')
+                if isinstance(encoding, unicode):
+                    self._bencoding = encoding.encode('ascii')
+                else:
+                    self._bencoding = encoding
+                self.encoding = PyBytes_AsString(self._bencoding)
+            if unicode_errors is None:
+                self.unicode_errors = 'strict'
             else:
-                self._berrors = unicode_errors
-            if self._berrors is not None:
+                if isinstance(unicode_errors, unicode):
+                    self._berrors = unicode_errors.encode('ascii')
+                else:
+                    self._berrors = unicode_errors
                 self.unicode_errors = PyBytes_AsString(self._berrors)
-            else:
-                self.unicode_errors = NULL
 
     def __dealloc__(self):
         PyMem_Free(self.pk.buf)


### PR DESCRIPTION
0.5.2 introduced a regression in `Packer`.  Specifying only `unicode_errors` without `encoding` results in `self.unicode_errors` *not* being set to the result of `PyBytes_AsString`.

Previously, `unicode_errors` was either set to `NULL` or to the result of `PyBytes_AsString`. This restores that behavior while also keeping the new `NULL` default behavior when both are unspecified.
Original defaults of `utf-8` and `strict` were restored to keep API compatibility until these deprecated options are finally removed.

See https://github.com/neovim/python-client/issues/299 for downstream issues. 