### PR TITLE
Use cython's cast for converting encoding and errors

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -1,5 +1,5 @@
 # coding: utf-8
-#cython: embedsignature=True
+#cython: embedsignature=True, c_string_encoding=ascii
 
 from cpython cimport *
 from cpython.version cimport PY_MAJOR_VERSION

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -1,5 +1,5 @@
 # coding: utf-8
-#cython: embedsignature=True
+#cython: embedsignature=True, c_string_encoding=ascii
 
 from cpython.version cimport PY_MAJOR_VERSION
 from cpython.bytes cimport (


### PR DESCRIPTION
Temporal bytes object is not needed in Python 3.3+.