### PR TITLE
Allow for easier construction of serializable objects

### DIFF
--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -18,7 +18,6 @@ class ExtType(object):
             raise ValueError("code must be 0~127")
         self.code = code
         self.data = data
-        return super(ExtType, cls).__new__(cls, code, data)
     
 
 import os

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -18,6 +18,10 @@ class ExtType(object):
             raise ValueError("code must be 0~127")
         self.code = code
         self.data = data
+        
+    def __eq__(self, other):
+        return isinstance(other, ExtType) and \
+        self.code == other.code and self.data == other.data
     
 
 import os

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -5,17 +5,21 @@ from msgpack.exceptions import *
 from collections import namedtuple
 
 
-class ExtType(namedtuple('ExtType', 'code data')):
+class ExtType(object):
     """ExtType represents ext type in msgpack."""
-    def __new__(cls, code, data):
+    __slots__ = ('code', 'data')
+    
+    def __init__(self, code, data):
         if not isinstance(code, int):
             raise TypeError("code must be int")
         if not isinstance(data, bytes):
             raise TypeError("data must be bytes")
         if not 0 <= code <= 127:
             raise ValueError("code must be 0~127")
+        self.code = code
+        self.data = data
         return super(ExtType, cls).__new__(cls, code, data)
-
+    
 
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):
@@ -64,3 +68,6 @@ loads = unpackb
 
 dump = pack
 dumps = packb
+
+# alias for compatbiliity to umsgpack
+Ext = ExtType

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -2,13 +2,9 @@
 from msgpack._version import version
 from msgpack.exceptions import *
 
-from collections import namedtuple
-
 
 class ExtType(object):
     """ExtType represents ext type in msgpack."""
-    __slots__ = ('code', 'data')
-    
     def __init__(self, code, data):
         if not isinstance(code, int):
             raise TypeError("code must be int")
@@ -18,11 +14,14 @@ class ExtType(object):
             raise ValueError("code must be 0~127")
         self.code = code
         self.data = data
-        
+
     def __eq__(self, other):
         return isinstance(other, ExtType) and \
         self.code == other.code and self.data == other.data
-    
+
+    def __hash__(self):
+        return hash((ExtType, self.code, self.data))
+
 
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -198,7 +198,7 @@ def unpackb(object packed, object object_hook=None, object list_hook=None,
             if ret is not None and type(ret) != ExtType:  # strict typecheck
                 return ret
         for cls in _subclasses(ExtType):
-            if code == getattr(cls, 'type', getattr(cls, 'code')):
+            if code == getattr(cls, 'type', getattr(cls, 'code', float('NaN'))):
                 return cls._unpackb(ExtType(code, data))
         return ExtType(code, data)
 
@@ -350,7 +350,7 @@ cdef class Unpacker(object):
                 if ret is not None and type(ret) != ExtType:  # strict typecheck
                     return ret
             for cls in _subclasses(ExtType):
-                if code == getattr(cls, 'type', getattr(cls, 'code')):
+                if code == getattr(cls, 'type', getattr(cls, 'code', float('NaN'))):
                     return cls._unpackb(ExtType(code, data))
             return ExtType(code, data)
 

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -322,7 +322,7 @@ class Unpacker(object):
     def _ext_hook(self, code, data):
         if self.__ext_hook is not None:
             ret = self.__ext_hook(code, data)
-            if not isinstance(ret, (None, ExtType)):
+            if ret is not None and not isinstance(ret, ExtType):
                 return ret
         for cls in _subclasses(ExtType):
             if code == getattr(cls, 'type', getattr(cls, 'code')):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -325,7 +325,7 @@ class Unpacker(object):
             if not isinstance(ret, (None, ExtType)):
                 return ret
         for cls in _subclasses(ExtType):
-            if code == getattr(cls, 'type'):
+            if code == getattr(cls, 'type', getattr(cls, 'code')):
                 return cls._unpackb(ExtType(code, data))
 
     def feed(self, next_bytes):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -301,7 +301,7 @@ class Unpacker(object):
             if ret is not None and type(ret) != ExtType:  # strict typecheck
                 return ret
         for cls in _subclasses(ExtType):
-            if code == getattr(cls, 'type', getattr(cls, 'code')):
+            if code == getattr(cls, 'type', getattr(cls, 'code', float('NaN'))):
                 return cls._unpackb(ExtType(code, data))
         return ExtType(code, data)
 

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -322,7 +322,7 @@ class Unpacker(object):
     def _ext_hook(self, code, data):
         if self.__ext_hook is not None:
             ret = self.__ext_hook(code, data)
-            if ret is not None and not isinstance(ret, ExtType):
+            if ret is not None and type(ret) != ExtType:  # strict typecheck
                 return ret
         for cls in _subclasses(ExtType):
             if code == getattr(cls, 'type', getattr(cls, 'code')):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -300,6 +300,7 @@ class Unpacker(object):
         self._object_hook = object_hook
         self._object_pairs_hook = object_pairs_hook
         self.__ext_hook = ext_hook
+        self._ext_returned = False
         self._max_str_len = max_str_len
         self._max_bin_len = max_bin_len
         self._max_array_len = max_array_len
@@ -323,9 +324,11 @@ class Unpacker(object):
         if self.__ext_hook is not None:
             ret = self.__ext_hook(code, data)
             if ret is not None and not isinstance(ret, ExtType):
+                self._ext_returned = True
                 return ret
         for cls in _subclasses(ExtType):
             if code == getattr(cls, 'type', getattr(cls, 'code')):
+                self._ext_returned = True
                 return cls._unpackb(ExtType(code, data))
 
     def feed(self, next_bytes):
@@ -663,7 +666,10 @@ class Unpacker(object):
                 obj = obj.decode('utf_8')
             return obj
         if typ == TYPE_EXT:
-            return self._ext_hook(n, bytes(obj))
+            ret = self._ext_hook(n, bytes(obj))
+            if self._ext_returned:
+                self._ext_returned = False
+                return ret
         if typ == TYPE_BIN:
             return bytes(obj)
         assert typ == TYPE_IMMEDIATE

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 import array
 import msgpack
-from msgpack import ExtType
+from msgpack import ExtType, Unpacker
 from collections import namedtuple
+from io import BytesIO
 
 
 def test_pack_ext_type():
@@ -105,5 +106,35 @@ def test_ext_namedtuple_inheritor():
             return cls(*msgpack.unpackb(ext.data))
 
     assert isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub)
-    
-    
+
+def test_ext_inheritor_Unpacker():
+    class Stub(ExtType):
+        code = type = 3
+
+        def __init__(self):
+            pass
+
+        @property
+        def data(self):
+            return msgpack.packb(None)
+
+        @classmethod
+        def _unpackb(cls, ext):
+            return cls()
+
+    unpacker = Unpacker(BytesIO(msgpack.packb(Stub())))
+    assert isinstance(unpacker.unpack(), Stub)
+
+def test_ext_namedtuple_inheritor_Unpacker():
+    class Stub(ExtType, namedtuple('_Stub', ['foo'])):
+        code = type = 4
+
+        def __init__(self, *args, **kwargs):
+            super(Stub, self).__init__(Stub.type, msgpack.packb(tuple(self)))
+
+        @classmethod
+        def _unpackb(cls, ext):
+            return cls(*msgpack.unpackb(ext.data))
+
+    unpacker = Unpacker(BytesIO(msgpack.packb(Stub(1))))
+    assert isinstance(unpacker.unpack(), Stub)

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -74,3 +74,35 @@ def test_overriding_hooks():
     testout = msgpack.packb(obj, default=default)
 
     assert refout == testout
+
+def test_ext_inheritor():
+    class Stub(ExtType):
+        type = 1
+
+        def __init__(self):
+            pass
+
+        @property
+        def data(self):
+            return msgpack.packb(None)
+
+        @classmethod
+        def _unpackb(cls, ext):
+            return cls()
+
+    self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
+
+def test_ext_namedtuple_inheritor():
+    class Stub(ExtType, namedtuple('_Stub', ['foo'])):
+        type = 2
+
+        def __init__(self, *args, **kwargs):
+            super(Stub, self).__init__(Stub.type, msgpack.packb(tuple(self)))
+
+        @classmethod
+        def _unpackb(cls, ext):
+            return cls(*msgpack.unpackb(ext.data))
+
+    self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub))
+    
+    

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -78,7 +78,7 @@ def test_overriding_hooks():
 
 def test_ext_inheritor():
     class Stub(ExtType):
-        type = 1
+        code = type = 1
 
         def __init__(self):
             pass
@@ -95,7 +95,7 @@ def test_ext_inheritor():
 
 def test_ext_namedtuple_inheritor():
     class Stub(ExtType, namedtuple('_Stub', ['foo'])):
-        type = 2
+        code = type = 2
 
         def __init__(self, *args, **kwargs):
             super(Stub, self).__init__(Stub.type, msgpack.packb(tuple(self)))

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import array
 import msgpack
 from msgpack import ExtType
+from collections import namedtuple
 
 
 def test_pack_ext_type():

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -79,7 +79,7 @@ def test_overriding_hooks():
 
 def test_ext_inheritor():
     class Stub(ExtType):
-        code = type = 1
+        code = type = 127
 
         def __init__(self):
             pass
@@ -96,7 +96,7 @@ def test_ext_inheritor():
 
 def test_ext_namedtuple_inheritor():
     class Stub(ExtType, namedtuple('_Stub', ['foo'])):
-        code = type = 2
+        code = type = 126
 
         def __init__(self, *args, **kwargs):
             super(Stub, self).__init__(Stub.type, msgpack.packb(tuple(self)))
@@ -109,7 +109,7 @@ def test_ext_namedtuple_inheritor():
 
 def test_ext_inheritor_Unpacker():
     class Stub(ExtType):
-        code = type = 3
+        code = type = 125
 
         def __init__(self):
             pass
@@ -127,7 +127,7 @@ def test_ext_inheritor_Unpacker():
 
 def test_ext_namedtuple_inheritor_Unpacker():
     class Stub(ExtType, namedtuple('_Stub', ['foo'])):
-        code = type = 4
+        code = type = 124
 
         def __init__(self, *args, **kwargs):
             super(Stub, self).__init__(Stub.type, msgpack.packb(tuple(self)))

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -91,7 +91,7 @@ def test_ext_inheritor():
         def _unpackb(cls, ext):
             return cls()
 
-    self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
+    assert isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub)
 
 def test_ext_namedtuple_inheritor():
     class Stub(ExtType, namedtuple('_Stub', ['foo'])):
@@ -104,6 +104,6 @@ def test_ext_namedtuple_inheritor():
         def _unpackb(cls, ext):
             return cls(*msgpack.unpackb(ext.data))
 
-    self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub))
+    assert isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub)
     
     


### PR DESCRIPTION
This pull request is similar to https://github.com/vsergeev/u-msgpack-python/pull/37 and has a fully compatible API.

This PR adds the ability to usefully inherit from ExtType. It changes three things:

1. Make Ext an alias for ExtType, to increase compatibility between this and umsgpack
2. Ensures that Ext inherits from object, so that we can detect its subclasses
3. Detects subclasses of Ext at unpack time, so that these classes do not need ext_handlers

In python3, you can have the pretty NamedTuple version by inheriting from an initially defined class. In python2, you can inherit from a function call to namedtuple(). In both cases, all that needs to happen is for the class to define a `type`/`code` variable, to define a `data` variable/property, and to define an `_unpackb` method for msgpack to hook onto.

This PR enables the following in Python 3

```python
from typing import NamedTuple
from msgpack import Ext, packb, unpackb
# Note that Ext is now an alias for ExtType, allowing 1 char
# change between libraries


class _Serializable3(NamedTuple):
    foo: str
    bar: int


class Serializable3(Ext, _Serializable3):
    type = 1

    def __init__(self, *args, **kwargs):
        super().__init__(Serializable3.type, packb(self[:]))

    @classmethod
    def _unpackb(cls, ext: Ext) -> 'Serializable3':
        return cls(*unpackb(ext.data))


class Serializable3Alt(Ext, NamedTuple('_Serializable3Alt', [('foo', str), ('bar', int)])):
    code = 2  # code works as well, if you'd like

    def __init__(self, *args, **kwargs):
        super().__init__(Serializable3Alt.type, packb(self[:]))

    @classmethod
    def _unpackb(cls, ext: Ext) -> 'Serializable3Alt':
        return cls(*unpackb(ext.data))
```

And the following in Python 2 or 3:

```python
from collections import namedtuple
from msgpack import Ext, packb, unpackb


class Serializable2(Ext, namedtuple('_Serializable2', ['foo', 'bar'])):
    type = 3

    def __init__(self, *args, **kwargs):
        super(Serializable2, self).__init__(Serializable2.type, packb(self[:]))

    @classmethod
    def _unpackb(cls, ext):
        return cls(*unpackb(ext.data))
```

This also enables for more flexible serialization through the use of dynamically calculated data:

```python
from msgpack import Ext, packb, unpackb


class SerializableStub(Ext):
    type = 4

    def __init__(self, foo):
        self.foo = foo
        # note that Ext is not initialized for this style

    @property
    def data(self):
        return packb((self.foo, ))

    @classmethod
    def _unpackb(cls, ext):
        return cls(*unpackb(ext.data))
```