### PR TITLE
Alternate fixes for jython and legacy c python.

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -213,7 +213,7 @@ class Unpacker(object):
             for o in unpacker:
                 process(o)
     """
-    
+
     def __init__(self, file_like=None, read_size=0, use_list=True, raw=True,
                  object_hook=None, object_pairs_hook=None, list_hook=None,
                  encoding=None, unicode_errors=None, max_buffer_size=0,


### PR DESCRIPTION
The original batch wasn't working for jython and seemed to be more a lack of implicit type casting in older objects and alternate implementation pythons.  This seems less intrusive, more straightforward and works on jython-2.7.1.