### PR TITLE
Support packing directly into a writer object

### DIFF
--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -33,8 +33,11 @@ def pack(o, stream, **kwargs):
 
     See :class:`Packer` for options.
     """
-    packer = Packer(**kwargs)
-    stream.write(packer.pack(o))
+    if 'writer' in kwargs:
+        packer = Packer(**kwargs)
+        stream.write(packer.pack(o))
+    else:
+        Packer(writer=stream, **kwargs).pack(o)
 
 
 def packb(o, **kwargs):

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -57,7 +57,7 @@ def testPackUTF32():  # deprecated
 
 def testPackBytes():
     test_data = [
-        b"", b"abcd", (b"defgh",),
+        b"", b"abcd", (b"defgh",), b"longlonglonglong" * 1024 * 1024
         ]
     for td in test_data:
         check(td)
@@ -65,6 +65,7 @@ def testPackBytes():
 def testPackByteArrays():
     test_data = [
         bytearray(b""), bytearray(b"abcd"), (bytearray(b"defgh"),),
+        bytearray(b"longlonglonglong" * 1024 * 1024)
         ]
     for td in test_data:
         check(td)

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -106,6 +106,8 @@ def test_unpack_tell():
     messages += [b'hello', b'hello'*1000, list(range(20)),
                  {i: bytes(i)*i for i in range(10)},
                  {i: bytes(i)*i for i in range(32)}]
+    messages += [[b'small stuff before the big one', b'b' * 1024 * 1024]]
+
     offsets = []
     for m in messages:
         pack(m, stream)


### PR DESCRIPTION
When packing larger objects, the current default behavior
of packing the entire object into a buffer and then writing
it into the provided output stream results in massive slowdowns.

To address this use case, Packer now accepts an optional `writer`
kwarg, which must be an object with a `write()` method. When this
argument is given:
  - the pure Python implementation writes directly to this object,
    completely bypassing StringIO
  - the C implementation only writes to this object when its internal
    buffer fills up, and to flush the remainder of the buffer at the
    end of a pack() call. Large elements may also bypass the buffer
    completely.

Add a few more tests to cover large values