### PR TITLE
StreamingPacker, take 2

### DIFF
--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -19,12 +19,115 @@ class ExtType(namedtuple('ExtType', 'code data')):
 
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):
-    from msgpack.fallback import Packer, unpackb, Unpacker
+    from msgpack.fallback import StreamingPacker, unpackb, Unpacker
 else:
     try:
-        from msgpack._cmsgpack import Packer, unpackb, Unpacker
+        from msgpack._cmsgpack import StreamingPacker, unpackb, Unpacker
     except ImportError:
-        from msgpack.fallback import Packer, unpackb, Unpacker
+        from msgpack.fallback import StreamingPacker, unpackb, Unpacker
+
+from .compat import StringIO, USING_STRINGBUILDER, PY2
+
+
+class Packer(StreamingPacker):
+    """
+    MessagePack Packer
+
+    usage:
+
+        packer = Packer()
+        astream.write(packer.pack(a))
+        astream.write(packer.pack(b))
+
+    Packer's constructor has some keyword arguments:
+
+    :param callable default:
+        Convert user type to builtin type that Packer supports.
+        See also simplejson's document.
+
+    :param bool use_single_float:
+        Use single precision float type for float. (default: False)
+
+    :param bool autoreset:
+        Reset buffer after each pack and return its content as `bytes`. (default: True).
+        If set this to false, use `bytes()` to get content and `.reset()` to clear buffer.
+
+    :param bool use_bin_type:
+        Use bin type introduced in msgpack spec 2.0 for bytes.
+        It also enables str8 type for unicode.
+
+    :param bool strict_types:
+        If set to true, types will be checked to be exact. Derived classes
+        from serializable types will not be serialized and will be
+        treated as unsupported type and forwarded to default.
+        Additionally tuples will not be serialized as lists.
+        This is useful when trying to implement accurate serialization
+        for python types.
+
+    :param str encoding:
+        (deprecated) Convert unicode to bytes with this encoding. (default: 'utf-8')
+
+    :param str unicode_errors:
+        Error handler for encoding unicode. (default: 'strict')
+    """
+    def __init__(self, default=None, encoding=None, unicode_errors=None,
+                 use_single_float=False, autoreset=True, use_bin_type=False,
+                 strict_types=False):
+        self._buffer = StringIO()
+        self._autoreset = autoreset
+        super(Packer, self).__init__(self._write, default=default, encoding=encoding, unicode_errors=unicode_errors,
+                                     use_single_float=use_single_float, use_bin_type=use_bin_type,
+                                     strict_types=strict_types)
+
+    def pack(self, obj):
+        try:
+            super(Packer, self).pack(obj)
+        except:
+            self._buffer = StringIO()  # force reset
+            raise
+        if self._autoreset:
+            return self._reset()
+
+    def pack_map_pairs(self, pairs):
+        super(Packer, self).pack_map_pairs(pairs)
+        if self._autoreset:
+            return self._reset()
+
+    def pack_array_header(self, n):
+        super(Packer, self).pack_array_header(n)
+        if self._autoreset:
+            return self._reset()
+
+    def pack_map_header(self, n):
+        super(Packer, self).pack_map_header(n)
+        if self._autoreset:
+            return self._reset()
+
+    def _write(self, data):
+        self._buffer.write(data)
+
+    def _reset(self):
+        ret = self._buffer.getvalue()
+        self._buffer = StringIO()
+        return ret
+
+    def bytes(self):
+        """Return internal buffer contents as bytes object"""
+        return self._buffer.getvalue()
+
+    def reset(self):
+        """Reset internal buffer.
+
+        This method is useful only when autoreset=False.
+        """
+        self._buffer = StringIO()
+
+    def getbuffer(self):
+        """Return view of internal buffer."""
+        if USING_STRINGBUILDER or PY2:
+            return memoryview(self.bytes())
+        else:
+            return self._buffer.getbuffer()
 
 
 def pack(o, stream, **kwargs):
@@ -33,8 +136,7 @@ def pack(o, stream, **kwargs):
 
     See :class:`Packer` for options.
     """
-    packer = Packer(**kwargs)
-    stream.write(packer.pack(o))
+    return StreamingPacker(stream.write, **kwargs).pack(o)
 
 
 def packb(o, **kwargs):

--- a/msgpack/_cmsgpack.pyx
+++ b/msgpack/_cmsgpack.pyx
@@ -1,4 +1,4 @@
 # coding: utf-8
 #cython: embedsignature=True, c_string_encoding=ascii, language_level=3
-include "_packer.pyx"
+include "_streamingpacker.pyx"
 include "_unpacker.pyx"

--- a/msgpack/compat.py
+++ b/msgpack/compat.py
@@ -1,0 +1,43 @@
+import sys
+
+if sys.version_info[0] == 2:
+    PY2 = True
+    int_types = (int, long)
+    def dict_iteritems(d):
+        return d.iteritems()
+else:
+    PY2 = False
+    int_types = int
+    unicode = str
+    xrange = range
+    def dict_iteritems(d):
+        return d.items()
+
+if hasattr(sys, 'pypy_version_info'):
+    # cStringIO is slow on PyPy, StringIO is faster.  However: PyPy's own
+    # StringBuilder is fastest.
+    from __pypy__ import newlist_hint
+    try:
+        from __pypy__.builders import BytesBuilder as StringBuilder
+    except ImportError:
+        from __pypy__.builders import StringBuilder
+    USING_STRINGBUILDER = True
+    class StringIO(object):
+        def __init__(self, s=b''):
+            if s:
+                self.builder = StringBuilder(len(s))
+                self.builder.append(s)
+            else:
+                self.builder = StringBuilder()
+        def write(self, s):
+            if isinstance(s, memoryview):
+                s = s.tobytes()
+            elif isinstance(s, bytearray):
+                s = bytes(s)
+            self.builder.append(s)
+        def getvalue(self):
+            return self.builder.build()
+else:
+    USING_STRINGBUILDER = False
+    from io import BytesIO as StringIO
+    newlist_hint = lambda size: []

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -57,7 +57,7 @@ def testPackUTF32():  # deprecated
 
 def testPackBytes():
     test_data = [
-        b"", b"abcd", (b"defgh",),
+        b"", b"abcd", (b"defgh",), b"longlonglonglong" * 1024 * 1024
         ]
     for td in test_data:
         check(td)
@@ -65,6 +65,7 @@ def testPackBytes():
 def testPackByteArrays():
     test_data = [
         bytearray(b""), bytearray(b"abcd"), (bytearray(b"defgh"),),
+        bytearray(b"longlonglonglong" * 1024 * 1024)
         ]
     for td in test_data:
         check(td)

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -106,6 +106,9 @@ def test_unpack_tell():
     messages += [b'hello', b'hello'*1000, list(range(20)),
                  {i: bytes(i)*i for i in range(10)},
                  {i: bytes(i)*i for i in range(32)}]
+    messages += [[b'small stuff before the big one', b'b' * 1024 * 1024]]
+    messages += [{i: b'longlong' * 1024 for i in range(4096)}]
+
     offsets = []
     for m in messages:
         pack(m, stream)


### PR DESCRIPTION
When packing larger objects, the current default behavior
of packing the entire object into a buffer and then writing
it into the provided output stream results in massive slowdowns.

To address this case, introduce a StreamingPacker which takes
a callable, to which bytes are sent as they are produced. This
function will typically be the write() method of a file-like
object, but it can be any callable that accepts bytes.

The pure Python implementation writes directly to this callback.

The C implementation only writes to this function when its internal
buffer fills up, and to flush the remainder of the buffer at the
end of a pack*() call. Large elements may also bypass the buffer
completely.

Packer is redefined as a thin wrapper around StreamingPacker to
avoid code duplication while keeping StreamingPacker as simple
as possible.

Add a few more tests to cover large values