### PR TITLE
use relative imports

### DIFF
--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-from msgpack._version import version
-from msgpack.exceptions import *
+from ._version import version
+from .exceptions import *
 
 from collections import namedtuple
 
@@ -19,12 +19,12 @@ class ExtType(namedtuple('ExtType', 'code data')):
 
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):
-    from msgpack.fallback import Packer, unpackb, Unpacker
+    from .fallback import Packer, unpackb, Unpacker
 else:
     try:
-        from msgpack._cmsgpack import Packer, unpackb, Unpacker
+        from ._cmsgpack import Packer, unpackb, Unpacker
     except ImportError:
-        from msgpack.fallback import Packer, unpackb, Unpacker
+        from .fallback import Packer, unpackb, Unpacker
 
 
 def pack(o, stream, **kwargs):

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -3,7 +3,7 @@
 from cpython cimport *
 from cpython.bytearray cimport PyByteArray_Check, PyByteArray_CheckExact
 
-from msgpack import ExtType
+from . import ExtType
 
 
 cdef extern from "Python.h":

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -12,14 +12,14 @@ from libc.string cimport *
 from libc.limits cimport *
 ctypedef unsigned long long uint64_t
 
-from msgpack.exceptions import (
+from .exceptions import (
     BufferFull,
     OutOfData,
     ExtraData,
     FormatError,
     StackError,
 )
-from msgpack import ExtType
+from . import ExtType
 
 
 cdef extern from "unpack.h":

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -59,7 +59,7 @@ else:
     newlist_hint = lambda size: []
 
 
-from msgpack.exceptions import (
+from .exceptions import (
     BufferFull,
     OutOfData,
     ExtraData,
@@ -67,7 +67,7 @@ from msgpack.exceptions import (
     StackError,
 )
 
-from msgpack import ExtType
+from . import ExtType
 
 
 EX_SKIP                 = 0


### PR DESCRIPTION
This should not change anything but makes it easier to bundle msgpack in other projects (where bundling involves copying msgpack's source code and exposing it under a different Python module name).

Some applications use msgpack to store persistent data and require a specific msgpack version (e.g. borgbackup). Bundling helps in case there is an (incompatible) version of msgpack in a system-wide install.

More background for this change in #356
