### PR TITLE
memoize stringly keys of objects

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -656,10 +656,10 @@ class Unpacker(object):
                 ret = {}
                 for _ in xrange(n):
                     key = self._unpack(EX_CONSTRUCT)
-                    if self._strict_map_key and type(key) not in (unicode, bytes):
-                        raise ValueError("%s is not allowed for map key" % str(type(key)))
                     if type(key) in (unicode, bytes):
                         key = self._memo.setdefault(key, key)
+                    elif self._strict_map_key:
+                        raise ValueError("%s is not allowed for map key" % str(type(key)))
                     ret[key] = self._unpack(EX_CONSTRUCT)
                 if self._object_hook is not None:
                     ret = self._object_hook(ret)

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -321,6 +321,8 @@ class Unpacker(object):
         self._max_ext_len = max_ext_len
         self._stream_offset = 0
 
+        self._memo = {}  # used to memoize keys to reduce memory consumption
+
         if list_hook is not None and not callable(list_hook):
             raise TypeError('`list_hook` is not callable')
         if object_hook is not None and not callable(object_hook):
@@ -656,6 +658,8 @@ class Unpacker(object):
                     key = self._unpack(EX_CONSTRUCT)
                     if self._strict_map_key and type(key) not in (unicode, bytes):
                         raise ValueError("%s is not allowed for map key" % str(type(key)))
+                    if type(key) in (unicode, bytes):
+                        key = self._memo.setdefault(key, key)
                     ret[key] = self._unpack(EX_CONSTRUCT)
                 if self._object_hook is not None:
                     ret = self._object_hook(ret)

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -190,10 +190,6 @@ static inline int unpack_callback_map(unpack_user* u, unsigned int n, msgpack_un
 
 static inline int unpack_callback_map_item(unpack_user* u, unsigned int current, msgpack_unpack_object* c, msgpack_unpack_object k, msgpack_unpack_object v)
 {
-    if (u->strict_map_key && !PyUnicode_CheckExact(k) && !PyBytes_CheckExact(k)) {
-        PyErr_Format(PyExc_ValueError, "%.100s is not allowed for map key", Py_TYPE(k)->tp_name);
-        return -1;
-    }
     if (PyUnicode_CheckExact(k) || PyBytes_CheckExact(k)) {
         PyObject *memokey = PyDict_GetItem(u->memo, k);
         if (memokey != NULL) {
@@ -208,6 +204,10 @@ static inline int unpack_callback_map_item(unpack_user* u, unsigned int current,
                 return -1;
             }
         }
+    }
+    else if (u->strict_map_key) {
+        PyErr_Format(PyExc_ValueError, "%.100s is not allowed for map key", Py_TYPE(k)->tp_name);
+        return -1;
     }
     if (u->has_pairs_hook) {
         msgpack_unpack_object item = PyTuple_Pack(2, k, v);

--- a/msgpack/unpack_template.h
+++ b/msgpack/unpack_template.h
@@ -73,6 +73,7 @@ static inline PyObject* unpack_data(unpack_context* ctx)
 static inline void unpack_clear(unpack_context *ctx)
 {
     Py_CLEAR(ctx->stack[0].obj);
+    Py_CLEAR(ctx->user.memo);
 }
 
 template <bool construct>

--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -65,6 +65,15 @@ def test_unpacker_ext_hook():
     assert unpacker.unpack() == {'a': ExtType(2, b'321')}
 
 
+def test_unpacker_shares_stringly_keys():
+    f = BytesIO(packb([{" a  ?!": 1}, {" a  ?!": 2}]))
+    unpacker = Unpacker(f)
+    d1, d2 = unpacker.unpack()
+    key1, = d1
+    key2, = d2
+    assert key1 is key2
+
+
 if __name__ == '__main__':
     test_unpack_array_header_from_file()
     test_unpacker_hook_refcnt()


### PR DESCRIPTION
When unpacking msgpack objects, store the keys that appear into a memo
dictionary to make them unique. This is useful, because for most sizable
msgpack files the same keys appear again and again, since many objects
have the same "shape" (set of keys). A similar optimization is done in
most json deserializers, eg in CPython:
https://github.com/python/cpython/blob/d89cea15ad37e873003fc74ec2c77660ab620b00/Modules/_json.c#L717

My totally unscientific results: I tried this on two big msgpack files,
a wikidata dump (92 MiB) and a dump of reddit comments (596 MiB). I am
reporting time spent deserializing and memory use of the resulting data
structure. I've included json deserialization numbers as a comparison.
The results I get on my old-ish laptop are:

```
wikidata
                      time   memory
CPython 3.7.5 before  3.42s  1279 MiB
CPython 3.7.5 after   3.43s   883 MiB
PyPy3 7.2 before      6.44s  1380 MiB
PyPy3 7.2 after       4.98s   965 MiB

CPython 3.7.5 json    4.13s   887 MiB
PyPy3 7.2 json        3.54s   958 MiB

reddit
CPython 3.7.5 before   5.62s  3412 MiB
CPython 3.7.5 after    5.20s  1754 MiB
PyPy3 7.2 before      14.72s  3782 MiB
PyPy3 7.2 after        8.37s  2086 MiB

CPython 3.7.5 json     8.64s  1753 MiB
PyPy3 7.2 json        10.52s  2052 MiB
```

For wikidata, there is only a memory improvement on CPython, the time
stays the same. For all other three variants (all of reddit, pypy on
wikidata) both time and memory improve significantly. The reason for the
memory improvements are due to the memoizing, time improves due to
better cache locality due to the smaller working set, and less time
spent in GC in the case of PyPy.