### PR TITLE
Add TimestampType and packing/unpacking support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,10 @@ API reference
 
 .. autoclass:: ExtType
 
+.. autoclass:: TimestampType
+    :members:
+    :special-members: __init__
+
 exceptions
 ----------
 

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -3,7 +3,6 @@ from ._version import version
 from .exceptions import *
 
 from collections import namedtuple
-from numbers import Number, Integral
 
 import struct
 import sys
@@ -36,14 +35,14 @@ class TimestampType:
 
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
-        if not isinstance(seconds, Number):
+        if not isinstance(seconds, (int, float)):
             raise TypeError("seconds must be numeric")
-        if not isinstance(nanoseconds, Number):
-            raise TypeError("nanoseconds must be numeric")
+        if not isinstance(nanoseconds, int):
+            raise TypeError("nanoseconds must be an integer")
         if nanoseconds:
             if nanoseconds < 0 or nanoseconds % 1 != 0 or nanoseconds > (1e9 - 1):
                 raise ValueError("nanoseconds must be a non-negative integer less than 999999999.")
-            if not isinstance(seconds, Integral):
+            if not isinstance(seconds, int):
                 raise ValueError("seconds must be an integer if also providing nanoseconds.")
             self.nanoseconds = nanoseconds
         else:
@@ -73,7 +72,7 @@ class TimestampType:
 
     def to_bytes(self):
         """Pack TimestampType into bytes."""
-        if 0 <= self.seconds < 17179869184:  # seconds is nonnegative and fits in 34 bits
+        if (self.seconds >> 34) == 0:  # seconds is non-negative and fits in 34 bits
             data64 = self.nanoseconds << 34 | self.seconds
             if data64 & 0xffffffff00000000 == 0:
                 # nanoseconds is zero and seconds < 2**32, so timestamp 32

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -7,8 +7,6 @@ from numbers import Number, Integral
 
 import struct
 import sys
-if sys.version_info[0] > 2:
-    long = int
 
 class ExtType(namedtuple('ExtType', 'code data')):
     """ExtType represents ext type in msgpack."""
@@ -48,7 +46,7 @@ class TimestampType(namedtuple('TimestampType', 'seconds, nanoseconds')):
         else:
             # round helps with floating point issues
             nanoseconds = int(round(seconds % 1 * 1e9, 0))
-        seconds = long(seconds // 1)
+        seconds = int(seconds // 1)
         return super(TimestampType, cls).__new__(cls, seconds, nanoseconds)
 
     @staticmethod

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -21,16 +21,18 @@ class ExtType(namedtuple('ExtType', 'code data')):
             raise ValueError("code must be 0~127")
         return super(ExtType, cls).__new__(cls, code, data)
 
-class TimestampType(namedtuple('TimestampType', 'seconds, nanoseconds')):
+
+class TimestampType:
+    __slots__ = ["seconds", "nanoseconds"]
     """TimestampType represents the Timestamp extension type in msgpack."""
-    def __new__(cls, seconds, nanoseconds=0):
-        """Create TimestampType namedtuple.
+    def __init__(self, seconds, nanoseconds=0):
+        """Create TimestampType.
 
         seconds: numeric
             Number of seconds since the UNIX epoch (00:00:00 UTC Jan 1 1970, minus leap seconds).
             May be negative.
         nanoseconds: int
-            Number of nanoseconds to add to `seconds` to get fractional time. Maximum is 999_999_999
+            Number of nanoseconds to add to `seconds` to get fractional time. Maximum is 999_999_999. Default is 0.
 
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
@@ -43,11 +45,15 @@ class TimestampType(namedtuple('TimestampType', 'seconds, nanoseconds')):
                 raise ValueError("nanoseconds must be a non-negative integer less than 999999999.")
             if not isinstance(seconds, Integral):
                 raise ValueError("seconds must be an integer if also providing nanoseconds.")
+            self.nanoseconds = nanoseconds
         else:
             # round helps with floating point issues
-            nanoseconds = int(round(seconds % 1 * 1e9, 0))
-        seconds = int(seconds // 1)
-        return super(TimestampType, cls).__new__(cls, seconds, nanoseconds)
+            self.nanoseconds = int(round(seconds % 1 * 1e9, 0))
+        self.seconds = int(seconds // 1)
+
+    def __repr__(self):
+        """String representation of TimestampType."""
+        return str.format("TimestampType(seconds={0}, nanoseconds={1})", self.seconds, self.nanoseconds)
 
     @staticmethod
     def from_bytes(b):
@@ -83,6 +89,7 @@ class TimestampType(namedtuple('TimestampType', 'seconds, nanoseconds')):
     def to_float_s(self):
         """Return a floating-point posix timestamp"""
         return self.seconds + self.nanoseconds/1e9
+
 
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -3,6 +3,8 @@ from ._version import version
 from .exceptions import *
 
 from collections import namedtuple
+import math
+from numbers import Number, Integral
 
 
 class ExtType(namedtuple('ExtType', 'code data')):
@@ -12,10 +14,74 @@ class ExtType(namedtuple('ExtType', 'code data')):
             raise TypeError("code must be int")
         if not isinstance(data, bytes):
             raise TypeError("data must be bytes")
+        if code == -1:
+            return TimestampType.from_bytes(data)
         if not 0 <= code <= 127:
             raise ValueError("code must be 0~127")
         return super(ExtType, cls).__new__(cls, code, data)
 
+class TimestampType(namedtuple('TimestampType', 'seconds, nanoseconds')):
+    """TimestampType represents the Timestamp extension type in msgpack."""
+    def __new__(cls, seconds, nanoseconds=0):
+        """Create TimestampType namedtuple.
+
+        seconds: numeric
+            Number of seconds since the UNIX epoch (00:00:00 UTC Jan 1 1970, minus leap seconds).
+            May be negative.
+        nanoseconds: int
+            Number of nanoseconds to add to `seconds` to get fractional time. Maximum is 999_999_999
+
+        Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
+        """
+        if not isinstance(seconds, Number):
+            raise TypeError("seconds must be numeric")
+        if not isinstance(nanoseconds, Number):
+            raise TypeError("nanoseconds must be numeric")
+        if nanoseconds:
+            if nanoseconds < 0 or nanoseconds % 1 != 0 or nanoseconds > (1e9 - 1):
+                raise ValueError("nanoseconds must be a non-negative integer less than 999999999.")
+            if not isinstance(seconds, Integral):
+                raise ValueError("seconds must be an integer if also providing nanoseconds.")
+        else:
+            # round helps with floating point issues
+            nanoseconds = int(round(seconds % 1 * 1e9, 0))
+        seconds = int(seconds // 1)
+        return super(TimestampType, cls).__new__(cls, seconds, nanoseconds)
+
+    @staticmethod
+    def from_bytes(b):
+        """Unpack bytes into a TimestampType."""
+        if len(b) == 4:
+            seconds_ = int.from_bytes(b, "big", signed=False)
+            nanoseconds_ = 0
+        elif len(b) == 8:
+            data64 = int.from_bytes(b, "big", signed=False)
+            seconds_ = data64 & 0x00000003ffffffff
+            nanoseconds_ = data64 >> 34
+        elif len(b) == 12:
+            nanoseconds_, seconds_ = struct.unpack("!Iq", b)
+        else:
+            raise ValueError("Timestamp type can only be created from 32, 64, or 96-bit byte objects")
+        return TimestampType(seconds_, nanoseconds_)
+
+    def to_bytes(self):
+        """Pack TimestampType into bytes."""
+        if 0 <= self.seconds < 17179869184:  # seconds is nonnegative and fits in 34 bits
+            data64 = self.nanoseconds << 34 | self.seconds
+            if data64 & 0xffffffff00000000 == 0:
+                # nanoseconds is zero and seconds < 2**32, so timestamp 32
+                data = self.seconds.to_bytes(4, "big", signed=False)
+            else:
+                # timestamp 64
+                data = data64.to_bytes(8, "big", signed=False)
+        else:
+            # timestamp 96
+            data = struct.pack("!Iq", self.nanoseconds, self.seconds)
+        return data
+
+    def to_float_s(self):
+        """Return a floating-point posix timestamp"""
+        return self.seconds + self.nanoseconds/1e9
 
 import os
 if os.environ.get('MSGPACK_PUREPYTHON'):

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -7,6 +7,9 @@ from collections import namedtuple
 import struct
 import sys
 
+if sys.version_info[0] > 2:
+    long = int
+
 class ExtType(namedtuple('ExtType', 'code data')):
     """ExtType represents ext type in msgpack."""
     def __new__(cls, code, data):
@@ -42,20 +45,20 @@ class TimestampType:
 
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
-        if not isinstance(seconds, (int, float)):
+        if not isinstance(seconds, (int, long, float)):
             raise TypeError("seconds must be numeric")
         if not isinstance(nanoseconds, int):
             raise TypeError("nanoseconds must be an integer")
         if nanoseconds:
             if nanoseconds < 0 or nanoseconds % 1 != 0 or nanoseconds > (1e9 - 1):
                 raise ValueError("nanoseconds must be a non-negative integer less than 999999999.")
-            if not isinstance(seconds, int):
+            if not isinstance(seconds, (int, long)):
                 raise ValueError("seconds must be an integer if also providing nanoseconds.")
             self.nanoseconds = nanoseconds
         else:
             # round helps with floating point issues
             self.nanoseconds = int(round(seconds % 1 * 1e9, 0))
-        self.seconds = int(seconds // 1)
+        self.seconds = long(seconds // 1)
 
     def __repr__(self):
         """String representation of TimestampType."""

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -7,9 +7,6 @@ from collections import namedtuple
 import struct
 import sys
 
-if sys.version_info[0] > 2:
-    long = int
-
 class ExtType(namedtuple('ExtType', 'code data')):
     """ExtType represents ext type in msgpack."""
     def __new__(cls, code, data):
@@ -45,20 +42,20 @@ class TimestampType:
 
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
-        if not isinstance(seconds, (int, long, float)):
+        if not isinstance(seconds, (int, float)):
             raise TypeError("seconds must be numeric")
         if not isinstance(nanoseconds, int):
             raise TypeError("nanoseconds must be an integer")
         if nanoseconds:
             if nanoseconds < 0 or nanoseconds % 1 != 0 or nanoseconds > (1e9 - 1):
                 raise ValueError("nanoseconds must be a non-negative integer less than 999999999.")
-            if not isinstance(seconds, (int, long)):
+            if not isinstance(seconds, int):
                 raise ValueError("seconds must be an integer if also providing nanoseconds.")
             self.nanoseconds = nanoseconds
         else:
             # round helps with floating point issues
             self.nanoseconds = int(round(seconds % 1 * 1e9, 0))
-        self.seconds = long(seconds // 1)
+        self.seconds = int(seconds // 1)
 
     def __repr__(self):
         """String representation of TimestampType."""

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -3,7 +3,6 @@ from ._version import version
 from .exceptions import *
 
 from collections import namedtuple
-import math
 from numbers import Number, Integral
 
 

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -22,16 +22,23 @@ class ExtType(namedtuple('ExtType', 'code data')):
 
 
 class TimestampType:
-    __slots__ = ["seconds", "nanoseconds"]
-    """TimestampType represents the Timestamp extension type in msgpack."""
-    def __init__(self, seconds, nanoseconds=0):
-        """Create TimestampType.
+    """TimestampType represents the Timestamp extension type in msgpack.
 
-        seconds: numeric
-            Number of seconds since the UNIX epoch (00:00:00 UTC Jan 1 1970, minus leap seconds).
-            May be negative.
-        nanoseconds: int
-            Number of nanoseconds to add to `seconds` to get fractional time. Maximum is 999_999_999. Default is 0.
+    When built with Cython, msgpack-python uses C methods to pack and unpack `TimestampType`. When using pure-Python
+    msgpack-python, :func:`to_bytes` and :func:`from_bytes` are used to pack and unpack `TimestampType`.
+    """
+    __slots__ = ["seconds", "nanoseconds"]
+
+    def __init__(self, seconds, nanoseconds=0):
+        """Initialize a TimestampType object.
+
+        :param seconds: Number of seconds since the UNIX epoch (00:00:00 UTC Jan 1 1970, minus leap seconds). May be
+            negative. If :code:`seconds` includes a fractional part, :code:`nanoseconds` must be 0.
+        :type seconds: int or float
+
+        :param nanoseconds: Number of nanoseconds to add to `seconds` to get fractional time. Maximum is 999_999_999.
+            Default is 0.
+        :type nanoseconds: int
 
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
@@ -54,9 +61,28 @@ class TimestampType:
         """String representation of TimestampType."""
         return str.format("TimestampType(seconds={0}, nanoseconds={1})", self.seconds, self.nanoseconds)
 
+    def __eq__(self, other):
+        """Check for equality with another TimestampType object"""
+        if type(other) is self.__class__:
+            return self.seconds == other.seconds and self.nanoseconds == other.nanoseconds
+        return False
+
+    def __ne__(self, other):
+        """not-equals method (see :func:`__eq__()`)"""
+        return not self.__eq__(other)
+
     @staticmethod
     def from_bytes(b):
-        """Unpack bytes into a TimestampType."""
+        """Unpack bytes into a `TimestampType` object.
+
+        Used for pure-Python msgpack unpacking.
+
+        :param b: Payload from msgpack ext message with code -1
+        :type b: bytes
+
+        :returns: TimestampType object unpacked from msgpack ext payload
+        :rtype: TimestampType
+        """
         if len(b) == 4:
             seconds = struct.unpack("!L", b)[0]
             nanoseconds = 0
@@ -71,7 +97,13 @@ class TimestampType:
         return TimestampType(seconds, nanoseconds)
 
     def to_bytes(self):
-        """Pack TimestampType into bytes."""
+        """Pack this TimestampType object into bytes.
+
+        Used for pure-Python msgpack packing.
+
+        :returns data: Payload for EXT message with code -1 (timestamp type)
+        :rtype: bytes
+        """
         if (self.seconds >> 34) == 0:  # seconds is non-negative and fits in 34 bits
             data64 = self.nanoseconds << 34 | self.seconds
             if data64 & 0xffffffff00000000 == 0:
@@ -86,7 +118,11 @@ class TimestampType:
         return data
 
     def to_float_s(self):
-        """Return a floating-point posix timestamp"""
+        """Get the timestamp as a floating-point value.
+
+        :returns: posix timestamp
+        :rtype: float
+        """
         return self.seconds + self.nanoseconds/1e9
 
 

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -4,8 +4,9 @@ from cpython cimport *
 from cpython.bytearray cimport PyByteArray_Check, PyByteArray_CheckExact
 
 cdef ExtType
+cdef TimestampType
 
-from . import ExtType
+from . import ExtType, TimestampType
 
 
 cdef extern from "Python.h":
@@ -251,6 +252,15 @@ cdef class Packer(object):
                 L = len(o.data)
                 if L > ITEM_LIMIT:
                     raise ValueError("EXT data is too large")
+                ret = msgpack_pack_ext(&self.pk, longval, L)
+                ret = msgpack_pack_raw_body(&self.pk, rawval, L)
+            elif type(o) is TimestampType if strict_types else isinstance(o, TimestampType):
+                # This should also be before Tuple because TimestampType is namedtuple.
+                code = -1
+                data = o.to_bytes()
+                L = len(data)
+                longval = code
+                rawval = data
                 ret = msgpack_pack_ext(&self.pk, longval, L)
                 ret = msgpack_pack_raw_body(&self.pk, rawval, L)
             elif PyList_CheckExact(o) if strict_types else (PyTuple_Check(o) or PyList_Check(o)):

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -19,7 +19,7 @@ from .exceptions import (
     FormatError,
     StackError,
 )
-from . import ExtType
+from . import ExtType, TimestampType
 
 
 cdef extern from "unpack.h":
@@ -31,6 +31,7 @@ cdef extern from "unpack.h":
         PyObject* object_hook
         PyObject* list_hook
         PyObject* ext_hook
+        PyObject* timestamp_t
         char *encoding
         char *unicode_errors
         Py_ssize_t max_str_len
@@ -98,6 +99,9 @@ cdef inline init_ctx(unpack_context *ctx,
         if not PyCallable_Check(ext_hook):
             raise TypeError("ext_hook must be a callable.")
         ctx.user.ext_hook = <PyObject*>ext_hook
+
+    # Add Timestamp type to the user object so it may be used in unpack.h
+    ctx.user.timestamp_t = <PyObject*>TimestampType
 
     ctx.user.encoding = encoding
     ctx.user.unicode_errors = unicode_errors

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -67,7 +67,7 @@ from .exceptions import (
     StackError,
 )
 
-from . import ExtType
+from . import ExtType, TimestampType
 
 
 EX_SKIP                 = 0
@@ -855,9 +855,13 @@ class Packer(object):
                 if self._use_float:
                     return self._buffer.write(struct.pack(">Bf", 0xca, obj))
                 return self._buffer.write(struct.pack(">Bd", 0xcb, obj))
-            if check(obj, ExtType):
-                code = obj.code
-                data = obj.data
+            if check(obj, (ExtType, TimestampType)):
+                if check(obj, TimestampType):
+                    code = -1
+                    data = obj.to_bytes()
+                else:
+                    code = obj.code
+                    data = obj.data
                 assert isinstance(code, int)
                 assert isinstance(data, bytes)
                 L = len(data)

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -306,6 +306,9 @@ static inline int unpack_callback_ext(unpack_user* u, const char* base, const ch
         return -1;
     }
     // length also includes the typecode, so the actual data is length-1
+#if PY_MAJOR_VERSION == 2
+    py = PyObject_CallFunction(u->ext_hook, "(is#)", (int)typecode, pos, (Py_ssize_t)length-1);
+#else
     if (typecode == -1) {
         msgpack_timestamp ts;
         if (unpack_timestamp(pos, length-1, &ts) == 0) {
@@ -314,12 +317,9 @@ static inline int unpack_callback_ext(unpack_user* u, const char* base, const ch
             py = NULL;
         }
     } else {
-#if PY_MAJOR_VERSION == 2
-        py = PyObject_CallFunction(u->ext_hook, "(is#)", (int)typecode, pos, (Py_ssize_t)length-1);
-#else
         py = PyObject_CallFunction(u->ext_hook, "(iy#)", (int)typecode, pos, (Py_ssize_t)length-1);
-#endif
     }
+#endif
     if (!py)
         return -1;
     *o = py;

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -306,9 +306,6 @@ static inline int unpack_callback_ext(unpack_user* u, const char* base, const ch
         return -1;
     }
     // length also includes the typecode, so the actual data is length-1
-#if PY_MAJOR_VERSION == 2
-    py = PyObject_CallFunction(u->ext_hook, "(is#)", (int)typecode, pos, (Py_ssize_t)length-1);
-#else
     if (typecode == -1) {
         msgpack_timestamp ts;
         if (unpack_timestamp(pos, length-1, &ts) == 0) {
@@ -317,9 +314,12 @@ static inline int unpack_callback_ext(unpack_user* u, const char* base, const ch
             py = NULL;
         }
     } else {
+#if PY_MAJOR_VERSION == 2
+        py = PyObject_CallFunction(u->ext_hook, "(is#)", (int)typecode, pos, (Py_ssize_t)length-1);
+#else
         py = PyObject_CallFunction(u->ext_hook, "(iy#)", (int)typecode, pos, (Py_ssize_t)length-1);
-    }
 #endif
+    }
     if (!py)
         return -1;
     *o = py;

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -1,0 +1,41 @@
+import msgpack
+from msgpack import TimestampType
+import time
+
+def test_timestamp_type():
+    # timestamp32
+    ts = TimestampType(2**32 - 1)
+    assert ts.to_bytes() == b"\xff\xff\xff\xff"
+    packed = msgpack.packb(ts)
+    assert packed == b"\xd6\xff" + ts.to_bytes()
+    unpacked = msgpack.unpackb(packed)
+    assert ts == unpacked
+    assert ts.seconds == 2**32 - 1 and ts.nanoseconds == 0
+
+
+    # timestamp64
+    ts = TimestampType(2**34 - 1, 999999999)
+    assert ts.to_bytes() == b"\xee\x6b\x27\xff\xff\xff\xff\xff"
+    packed = msgpack.packb(ts)
+    assert packed == b"\xd7\xff" + ts.to_bytes()
+    unpacked = msgpack.unpackb(packed)
+    assert ts == unpacked
+    assert ts.seconds == 2**34 - 1 and ts.nanoseconds == 999999999
+
+    # timestamp96
+    ts = TimestampType(2**63 - 1, 999999999)
+    assert ts.to_bytes() == b"\x3b\x9a\xc9\xff\x7f\xff\xff\xff\xff\xff\xff\xff"
+    packed = msgpack.packb(ts)
+    assert packed == b"\xc7\x0c\xff" + ts.to_bytes()
+    unpacked = msgpack.unpackb(packed)
+    assert ts == unpacked
+    assert ts.seconds == 2**63 - 1 and ts.nanoseconds == 999999999
+
+    # negative fractional
+    ts = TimestampType(-2.3)  #s: -3, ns: 700000000
+    assert ts.to_bytes() == b"\x29\xb9\x27\x00\xff\xff\xff\xff\xff\xff\xff\xfd"
+    packed = msgpack.packb(ts)
+    assert packed == b"\xc7\x0c\xff" + ts.to_bytes()
+    unpacked = msgpack.unpackb(packed)
+    assert ts == unpacked
+    assert ts.seconds == -3 and ts.nanoseconds == 700000000

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -1,8 +1,13 @@
+import sys
+import warnings
+
 import msgpack
 from msgpack import TimestampType
-import time
 
 def test_timestamp_type():
+    if sys.version_info[0] < 3:
+        warnings.warn("msgpack-python does not support TimestampType in Python2.")
+        return
     # timestamp32
     ts = TimestampType(2**32 - 1)
     assert ts.to_bytes() == b"\xff\xff\xff\xff"


### PR DESCRIPTION
Here's my attempt at addressing #316. I made a TimestampType that can be packed/unpacked. I did not add any `datetime` conversions, but it will accept a floating-point seconds value for creation and can output to float with `to_float_s`. Also included a test. 

I tried to think it through pretty well and keep it 2/3 compatible. Let me know what you think.