### PR TITLE
build: Don't test C extension on CPython 2.7 under Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = {py27,py35,py36,py37,py38}-{c,pure},{pypy,pypy3}-pure,py27-x86,py34-x86
+envlist =
+    py27-pure,
+    {py35,py36,py37,py38}-{c,pure},
+    {pypy,pypy3}-pure,
+    py27-x86,
+    py34-x86,
 
 [variants:pure]
 setenv=


### PR DESCRIPTION
The py27-c variant is failing under Tox, with

```
py27-c run-test-pre: PYTHONHASHSEED='1597877995'
py27-c runtests: commands[0] | python -c 'from msgpack import _cmsgpack'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name _cmsgpack
ERROR: InvocationError for command
'/home/alex/src/msgpack-python/.tox/py27-c/bin/python -c from msgpack
import _cmsgpack' (exited with code 1)
```

As the Changelog notes, release 1.0 will drop support for the native
extension on CPython 2.x. So there seems little benefit of testing it.