### PR TITLE
Fix an example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ It is also possible to pack/unpack custom data types. Here is an example for
     }
 
     def decode_datetime(obj):
-        if b'__datetime__' in obj:
+        if '__datetime__' in obj:
             obj = datetime.datetime.strptime(obj["as_str"], "%Y%m%dT%H:%M:%S.%f")
         return obj
 


### PR DESCRIPTION
The example to unpack a datetime does not work on python3 at least because the condition is based on a binary string instead of an unicode one, so I changed it