### PR TITLE
fix: allow for timestamps before UNIX epoch

### DIFF
--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -178,7 +178,7 @@ class Timestamp(object):
 
         :rtype: datetime.
         """
-        return datetime.datetime.fromtimestamp(self.to_unix(), _utc)
+        return datetime.datetime.fromtimestamp(0, _utc) + datetime.timedelta(seconds=self.to_unix())
 
     @staticmethod
     def from_datetime(dt):


### PR DESCRIPTION
This addresses the issue mentioned here: https://stackoverflow.com/questions/17231711/how-to-create-datetime-from-a-negative-epoch-in-python/17231712