### PR TITLE
fix: allow for timestamps before UNIX epoch

### DIFF
--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -178,7 +178,9 @@ class Timestamp(object):
 
         :rtype: datetime.
         """
-        return datetime.datetime.fromtimestamp(self.to_unix(), _utc)
+        return datetime.datetime.fromtimestamp(0, _utc) + datetime.timedelta(
+            seconds=self.to_unix()
+        )
 
     @staticmethod
     def from_datetime(dt):


### PR DESCRIPTION
`datetime.datetime.fromtimestamp(-1)` does not work (at least not on Win10, Python 3.7).
A mitigation mentioned [here](https://stackoverflow.com/questions/17231711/how-to-create-datetime-from-a-negative-epoch-in-python/17231712) is to use
```python
datetime.datetime.fromtimestamp(0) + datetime.timedelta(seconds=-1)
```
instead.