### PR TITLE
Setup Timestamp to support rich comparisons

### DIFF
--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from collections import namedtuple
+from functools import total_ordering
 import datetime
 import sys
 import struct
@@ -31,6 +32,7 @@ class ExtType(namedtuple("ExtType", "code data")):
         return super(ExtType, cls).__new__(cls, code, data)
 
 
+@total_ordering
 class Timestamp(object):
     """Timestamp represents the Timestamp extension type in msgpack.
 
@@ -83,6 +85,14 @@ class Timestamp(object):
     def __ne__(self, other):
         """not-equals method (see :func:`__eq__()`)"""
         return not self.__eq__(other)
+
+    def __lt__(self, other):
+        """Check for less than with another Timestamp object"""
+        if type(other) is self.__class__:
+            return (
+                (self.seconds, self.nanoseconds) < (other.seconds, other.nanoseconds)
+            )
+        return NotImplemented
 
     def __hash__(self):
         return hash((self.seconds, self.nanoseconds))

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -89,9 +89,7 @@ class Timestamp(object):
     def __lt__(self, other):
         """Check for less than with another Timestamp object"""
         if type(other) is self.__class__:
-            return (
-                (self.seconds, self.nanoseconds) < (other.seconds, other.nanoseconds)
-            )
+            return (self.seconds, self.nanoseconds) < (other.seconds, other.nanoseconds)
         return NotImplemented
 
     def __hash__(self):

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -129,3 +129,13 @@ def test_pack_datetime():
     assert x
     assert x[0] == dt
     assert msgpack.unpackb(packed) is None
+
+
+def test_timestamp_comparisons():
+    t = Timestamp(42, 14000)
+    t2 = Timestamp(42, 14001)
+    assert t < t2
+    t3 = Timestamp(43, 14000)
+    assert t3 > t1
+    assert t3 >= t3
+    assert t1 <= t1

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -136,6 +136,6 @@ def test_timestamp_comparisons():
     t2 = Timestamp(42, 14001)
     assert t < t2
     t3 = Timestamp(43, 14000)
-    assert t3 > t1
+    assert t3 > t
     assert t3 >= t3
-    assert t1 <= t1
+    assert t <= t


### PR DESCRIPTION
When working with Timestamp objects I was surprised to find out they couldn't be compared to each other beyond eq and ne. 