### PR TITLE
Remove redundant code

### DIFF
--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -90,10 +90,3 @@ def test_unpacker_tell_read_bytes():
         assert obj == unp
         assert pos == unpacker.tell()
         assert unpacker.read_bytes(n) == raw
-
-
-if __name__ == "__main__":
-    test_unpack_array_header_from_file()
-    test_unpacker_hook_refcnt()
-    test_unpacker_ext_hook()
-    test_unpacker_tell()


### PR DESCRIPTION
It looks like you are using `pytest`. `pytest` has automatic test discovery. There is no need for test files to have `__main__`. Also: this code was out of date - it executes only 4 out of 5 tests.