### PR TITLE
Fix the discrepancies between the fallback and the extension

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -442,10 +442,10 @@ cdef class Unpacker(object):
         self.buf_tail = tail + _buf_len
 
     cdef read_from_file(self):
-        next_bytes = self.file_like_read(
-                min(self.read_size,
-                    self.max_buffer_size - (self.buf_tail - self.buf_head)
-                    ))
+        free_space = self.max_buffer_size - (self.buf_tail - self.buf_head)
+        if free_space <= 0:
+            raise ValueError("Exceeded max_buffer_size of %s" % self.max_buffer_size)
+        next_bytes = self.file_like_read(min(self.read_size, free_space))
         if next_bytes:
             self.append_buffer(PyBytes_AsString(next_bytes), PyBytes_Size(next_bytes))
         else:

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -501,10 +501,6 @@ class Unpacker(object):
             self._buff_i += size
         elif 0xD4 <= b <= 0xD8:
             size, fmt, typ = _MSGPACK_HEADERS[b]
-            if self._max_ext_len < size:
-                raise ValueError(
-                    "%s exceeds max_ext_len(%s)" % (size, self._max_ext_len)
-                )
             self._reserve(size + 1)
             n, obj = _unpack_from(fmt, self._buffer, self._buff_i)
             self._buff_i += size + 1

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -490,8 +490,6 @@ class Unpacker(object):
             self._reserve(size)
             L, n = _unpack_from(fmt, self._buffer, self._buff_i)
             self._buff_i += size
-            if L > self._max_ext_len:
-                raise ValueError("%s exceeds max_ext_len(%s)" % (L, self._max_ext_len))
             obj = self._read(L)
         elif 0xCA <= b <= 0xD3:
             size, fmt = _MSGPACK_HEADERS[b]

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -418,7 +418,8 @@ class Unpacker(object):
         if self._feeding:
             self._buff_i = self._buf_checkpoint
             raise OutOfData
-
+        if n > self._max_buffer_size:
+            raise ValueError("Exceeded max_buffer_size of %s" % self._max_buffer_size)
         # Strip buffer before checkpoint before reading file.
         if self._buf_checkpoint > 0:
             del self._buffer[: self._buf_checkpoint]
@@ -483,8 +484,6 @@ class Unpacker(object):
             else:
                 n = self._buffer[self._buff_i]
             self._buff_i += size
-            if n > self._max_bin_len:
-                raise ValueError("%s exceeds max_bin_len(%s)" % (n, self._max_bin_len))
             obj = self._read(n)
         elif 0xC7 <= b <= 0xC9:
             size, fmt, typ = _MSGPACK_HEADERS[b]

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -455,8 +455,6 @@ class Unpacker(object):
         elif b & 0b11100000 == 0b10100000:
             n = b & 0b00011111
             typ = TYPE_RAW
-            if n > self._max_str_len:
-                raise ValueError("%s exceeds max_str_len(%s)" % (n, self._max_str_len))
             obj = self._read(n)
         elif b & 0b11110000 == 0b10010000:
             n = b & 0b00001111

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -518,8 +518,6 @@ class Unpacker(object):
             else:
                 n = self._buffer[self._buff_i]
             self._buff_i += size
-            if n > self._max_str_len:
-                raise ValueError("%s exceeds max_str_len(%s)" % (n, self._max_str_len))
             obj = self._read(n)
         elif 0xDC <= b <= 0xDD:
             size, fmt, typ = _MSGPACK_HEADERS[b]

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -231,11 +231,6 @@ static inline int unpack_callback_map_end(unpack_user* u, msgpack_unpack_object*
 
 static inline int unpack_callback_raw(unpack_user* u, const char* b, const char* p, unsigned int l, msgpack_unpack_object* o)
 {
-    if (l > u->max_str_len) {
-        PyErr_Format(PyExc_ValueError, "%u exceeds max_str_len(%zd)", l, u->max_str_len);
-        return -1;
-    }
-
     PyObject *py;
 
     if (u->raw) {

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -251,11 +251,6 @@ static inline int unpack_callback_raw(unpack_user* u, const char* b, const char*
 
 static inline int unpack_callback_bin(unpack_user* u, const char* b, const char* p, unsigned int l, msgpack_unpack_object* o)
 {
-    if (l > u->max_bin_len) {
-        PyErr_Format(PyExc_ValueError, "%u exceeds max_bin_len(%zd)", l, u->max_bin_len);
-        return -1;
-    }
-
     PyObject *py = PyBytes_FromStringAndSize(p, l);
     if (!py)
         return -1;

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -300,10 +300,6 @@ static int unpack_callback_ext(unpack_user* u, const char* base, const char* pos
         PyErr_SetString(PyExc_AssertionError, "u->ext_hook cannot be NULL");
         return -1;
     }
-    if (length-1 > u->max_ext_len) {
-        PyErr_Format(PyExc_ValueError, "%u exceeds max_ext_len(%zd)", length, u->max_ext_len);
-        return -1;
-    }
 
     PyObject *py = NULL;
     // length also includes the typecode, so the actual data is length-1

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -56,6 +56,8 @@ def test_exceed_max_bin_len(impl, use_unpack):
     when the data is supplied via feed() leading to a discrepancy: when you
     feed() a header of a bin, str or ext that is too large and call unpack()
     the extension asks for more data but the fallback raises a ValueError
+
+    See https://github.com/msgpack/msgpack-python/pull/464#issuecomment-786506188
     """
     if impl is None:
         skip("C extension not awailable")

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -80,3 +80,20 @@ def test_exceed_max_bin_len(type, impl, use_unpack):
     else:
         with raises(StopIteration):
             next(u)
+
+
+@mark.parametrize("impl", [fallback, _cmsgpack])
+@mark.parametrize("use_unpack", [True, False])
+def test_fixext_discrepancy(impl, use_unpack):
+    if impl is None:
+        skip("C extension not awailable")
+
+    u = impl.Unpacker(max_buffer_size=1)
+    u.feed(b"\xd5")
+
+    if use_unpack:
+        with raises(OutOfData):
+            u.unpack()
+    else:
+        with raises(StopIteration):
+            next(u)

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -1,4 +1,5 @@
 import io
+import struct
 from pytest import raises, mark, skip
 
 from msgpack import fallback
@@ -23,7 +24,7 @@ def test_exceed_max_buffer_size(impl, use_unpack):
 
     buffer_size = 11
     max_buffer_size = 10
-    f = io.BytesIO(b"\xc6" + buffer_size.to_bytes(4, "big") + b"z" * buffer_size)
+    f = io.BytesIO(b"\xc6" + struct.pack(">I", buffer_size) + b"z" * buffer_size)
     u = impl.Unpacker(f, max_buffer_size=max_buffer_size)
 
     with raises(ValueError):

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -12,7 +12,10 @@ except ImportError:
 def test_exceed_max_buffer_size(use_unpack):
     """The C extension used to have a bug: when reading objects that require
     a buffer bigger than max_buffer_size it would behave as if there is not
-    enough data"""
+    enough data
+
+    See https://github.com/msgpack/msgpack-python/pull/464#issuecomment-786457374
+    """
     buffer_size = 11
     max_buffer_size = 10
     f = io.BytesIO(b"\xc6" + buffer_size.to_bytes(4, "big") + b"z" * buffer_size)

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -35,9 +35,16 @@ def test_exceed_max_buffer_size(impl, use_unpack):
             next(u)
 
 
+@mark.parametrize(
+    "type",
+    [
+        b"\xc6",  # bin 32
+        b"\xdb",  # str 32
+    ],
+)
 @mark.parametrize("impl", [fallback, _cmsgpack])
 @mark.parametrize("use_unpack", [True, False])
-def test_exceed_max_bin_len(impl, use_unpack):
+def test_exceed_max_bin_len(type, impl, use_unpack):
     """msgpack attempts to prevent denial of service attacks that cause the
     parser to allocate too much memory. When the input is supplied via feed()
     this protection is implemented the same in both the extension and
@@ -65,7 +72,7 @@ def test_exceed_max_bin_len(impl, use_unpack):
     bin_len = 11
     max_buffer_size = 10
     u = impl.Unpacker(max_buffer_size=max_buffer_size)
-    u.feed(b"\xc6" + struct.pack(">I", bin_len))
+    u.feed(type + struct.pack(">I", bin_len))
     if use_unpack:
         with raises(OutOfData):
             u.unpack()

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -106,7 +106,7 @@ def test_fixstr_discrepancy(impl, use_unpack):
         skip("C extension not awailable")
 
     u = impl.Unpacker(max_buffer_size=1)
-    u.feed(bytes([0b10100010]))
+    u.feed(struct.pack("B", 0b10100010))
 
     if use_unpack:
         with raises(OutOfData):

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -1,5 +1,7 @@
 import io
-from pytest import raises, mark
+from pytest import raises, mark, skip
+
+from msgpack import fallback
 
 try:
     from msgpack import _cmsgpack
@@ -7,19 +9,22 @@ except ImportError:
     _cmsgpack = None
 
 
-@mark.skipif(_cmsgpack is None, reason="C extension not awailable")
+@mark.parametrize("impl", [fallback, _cmsgpack])
 @mark.parametrize("use_unpack", [True, False])
-def test_exceed_max_buffer_size(use_unpack):
+def test_exceed_max_buffer_size(impl, use_unpack):
     """The C extension used to have a bug: when reading objects that require
     a buffer bigger than max_buffer_size it would behave as if there is not
     enough data
 
     See https://github.com/msgpack/msgpack-python/pull/464#issuecomment-786457374
     """
+    if impl is None:
+        skip("C extension not awailable")
+
     buffer_size = 11
     max_buffer_size = 10
     f = io.BytesIO(b"\xc6" + buffer_size.to_bytes(4, "big") + b"z" * buffer_size)
-    u = _cmsgpack.Unpacker(f, max_buffer_size=max_buffer_size)
+    u = impl.Unpacker(f, max_buffer_size=max_buffer_size)
 
     with raises(ValueError):
         if use_unpack:

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -45,7 +45,7 @@ def test_exceed_max_buffer_size(impl, use_unpack):
 )
 @mark.parametrize("impl", [fallback, _cmsgpack])
 @mark.parametrize("use_unpack", [True, False])
-def test_exceed_max_bin_len(type, impl, use_unpack):
+def test_bin_str_ext_32_discrepancy(type, impl, use_unpack):
     """msgpack attempts to prevent denial of service attacks that cause the
     parser to allocate too much memory. When the input is supplied via feed()
     this protection is implemented the same in both the extension and
@@ -85,6 +85,7 @@ def test_exceed_max_bin_len(type, impl, use_unpack):
 @mark.parametrize("impl", [fallback, _cmsgpack])
 @mark.parametrize("use_unpack", [True, False])
 def test_fixext_discrepancy(impl, use_unpack):
+    """See test_bin_str_ext_32_discrepancy"""
     if impl is None:
         skip("C extension not awailable")
 
@@ -102,6 +103,7 @@ def test_fixext_discrepancy(impl, use_unpack):
 @mark.parametrize("impl", [fallback, _cmsgpack])
 @mark.parametrize("use_unpack", [True, False])
 def test_fixstr_discrepancy(impl, use_unpack):
+    """See test_bin_str_ext_32_discrepancy"""
     if impl is None:
         skip("C extension not awailable")
 

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -1,0 +1,25 @@
+import io
+from pytest import raises, mark
+
+try:
+    from msgpack import _cmsgpack
+except ImportError:
+    _cmsgpack = None
+
+
+@mark.skipif(_cmsgpack is None, reason="C extension not awailable")
+@mark.parametrize("use_unpack", [True, False])
+def test_exceed_max_buffer_size(use_unpack):
+    """The C extension used to have a bug: when reading objects that require
+    a buffer bigger than max_buffer_size it would behave as if there is not
+    enough data"""
+    buffer_size = 11
+    max_buffer_size = 10
+    f = io.BytesIO(b"\xc6" + buffer_size.to_bytes(4, "big") + b"z" * buffer_size)
+    u = _cmsgpack.Unpacker(f, max_buffer_size=max_buffer_size)
+
+    with raises(ValueError):
+        if use_unpack:
+            u.unpack()
+        else:
+            next(u)

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -97,3 +97,20 @@ def test_fixext_discrepancy(impl, use_unpack):
     else:
         with raises(StopIteration):
             next(u)
+
+
+@mark.parametrize("impl", [fallback, _cmsgpack])
+@mark.parametrize("use_unpack", [True, False])
+def test_fixstr_discrepancy(impl, use_unpack):
+    if impl is None:
+        skip("C extension not awailable")
+
+    u = impl.Unpacker(max_buffer_size=1)
+    u.feed(bytes([0b10100010]))
+
+    if use_unpack:
+        with raises(OutOfData):
+            u.unpack()
+    else:
+        with raises(StopIteration):
+            next(u)

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -2,6 +2,7 @@ import io
 import struct
 from pytest import raises, mark, skip
 
+from msgpack.exceptions import OutOfData
 from msgpack import fallback
 
 try:
@@ -31,4 +32,41 @@ def test_exceed_max_buffer_size(impl, use_unpack):
         if use_unpack:
             u.unpack()
         else:
+            next(u)
+
+
+@mark.parametrize("impl", [fallback, _cmsgpack])
+@mark.parametrize("use_unpack", [True, False])
+def test_exceed_max_bin_len(impl, use_unpack):
+    """msgpack attempts to prevent denial of service attacks that cause the
+    parser to allocate too much memory. When the input is supplied via feed()
+    this protection is implemented the same in both the extension and
+    the fallback: feed() raises BufferFull. When the input is supplied via a
+    file the extension and the fallback implement the protection differently:
+    Extension:
+        1. If there is enough data in the buffer to parse an object go to 5
+        2. If the buffer is max_buffer_size and is full raise an error
+        3. Read some data and append it to the buffer
+        4. Go to 1
+        5. Return the object
+    Fallback:
+        1. Check that the length of a bin/str/ext is in the sane range
+        2. Read exactly that many bytes
+    At the time of writing the fallback applies the length sanity check even
+    when the data is supplied via feed() leading to a discrepancy: when you
+    feed() a header of a bin, str or ext that is too large and call unpack()
+    the extension asks for more data but the fallback raises a ValueError
+    """
+    if impl is None:
+        skip("C extension not awailable")
+
+    bin_len = 11
+    max_buffer_size = 10
+    u = impl.Unpacker(max_buffer_size=max_buffer_size)
+    u.feed(b"\xc6" + struct.pack(">I", bin_len))
+    if use_unpack:
+        with raises(OutOfData):
+            u.unpack()
+    else:
+        with raises(StopIteration):
             next(u)

--- a/test/test_discrepancy.py
+++ b/test/test_discrepancy.py
@@ -40,6 +40,7 @@ def test_exceed_max_buffer_size(impl, use_unpack):
     [
         b"\xc6",  # bin 32
         b"\xdb",  # str 32
+        b"\xc9",  # ext 32
     ],
 )
 @mark.parametrize("impl", [fallback, _cmsgpack])
@@ -72,7 +73,7 @@ def test_exceed_max_bin_len(type, impl, use_unpack):
     bin_len = 11
     max_buffer_size = 10
     u = impl.Unpacker(max_buffer_size=max_buffer_size)
-    u.feed(type + struct.pack(">I", bin_len))
+    u.feed(type + struct.pack(">I", bin_len) + b"\0")
     if use_unpack:
         with raises(OutOfData):
             u.unpack()

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -83,20 +83,6 @@ def test_max_map_len():
         unpacker.unpack()
 
 
-def test_max_ext_len():
-    d = ExtType(42, b"abc")
-    packed = packb(d)
-
-    unpacker = Unpacker(max_ext_len=3)
-    unpacker.feed(packed)
-    assert unpacker.unpack() == d
-
-    unpacker = Unpacker(max_ext_len=2)
-    with pytest.raises(UnpackValueError):
-        unpacker.feed(packed)
-        unpacker.unpack()
-
-
 # PyPy fails following tests because of constant folding?
 # https://bugs.pypy.org/issue1721
 # @pytest.mark.skipif(True, reason="Requires very large memory.")

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -55,20 +55,6 @@ def test_max_str_len():
         unpacker.unpack()
 
 
-def test_max_bin_len():
-    d = b"x" * 3
-    packed = packb(d, use_bin_type=True)
-
-    unpacker = Unpacker(max_bin_len=3)
-    unpacker.feed(packed)
-    assert unpacker.unpack() == d
-
-    unpacker = Unpacker(max_bin_len=2)
-    with pytest.raises(UnpackValueError):
-        unpacker.feed(packed)
-        unpacker.unpack()
-
-
 def test_max_array_len():
     d = [1, 2, 3]
     packed = packb(d)

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -41,20 +41,6 @@ def test_map_header():
         packer.pack_array_header(2 ** 32)
 
 
-def test_max_str_len():
-    d = "x" * 3
-    packed = packb(d)
-
-    unpacker = Unpacker(max_str_len=3, raw=False)
-    unpacker.feed(packed)
-    assert unpacker.unpack() == d
-
-    unpacker = Unpacker(max_str_len=2, raw=False)
-    with pytest.raises(UnpackValueError):
-        unpacker.feed(packed)
-        unpacker.unpack()
-
-
 def test_max_array_len():
     d = [1, 2, 3]
     packed = packb(d)

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,6 @@ envlist =
     py34-x86,
 isolated_build = true
 
-[variants:pure]
-setenv=
-    MSGPACK_PUREPYTHON=x
-
 [testenv]
 deps=
     pytest
@@ -20,6 +16,8 @@ commands=
     c,x86: python -c 'from msgpack import _cmsgpack'
     c,x86: py.test
     pure: py.test
+setenv=
+    pure: MSGPACK_PUREPYTHON=x
 
 [testenv:py27-x86]
 basepython=python2.7-x86


### PR DESCRIPTION
I have found a number of cases where the fallback unpacker and the extension unpacker behave differently. I think it would be best if the fallback was a drop-in replacement for the extension.