### PR TITLE
Fix tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,6 @@ envlist =
     py34-x86,
 isolated_build = true
 
-[variants:pure]
-setenv=
-    MSGPACK_PUREPYTHON=x
-
 [testenv]
 deps=
     pytest
@@ -20,6 +16,8 @@ commands=
     c,x86: python -c 'from msgpack import _cmsgpack'
     c,x86: py.test
     pure: py.test
+setenv=
+    pure: MSGPACK_PUREPYTHON=x
 
 [testenv:py27-x86]
 basepython=python2.7-x86


### PR DESCRIPTION
There is no such thing as [variants] in the tox syntax. This resulted
in MSGPACK_PUREPYTHON being unset in the "pure" test environments