### PR TITLE
Nicer error when packing a datetime without tzinfo

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -274,7 +274,9 @@ cdef class Packer(object):
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, <char*>view.buf, L)
                 PyBuffer_Release(&view);
-            elif self.datetime and PyDateTime_CheckExact(o) and datetime_tzinfo(o) is not None:
+            elif self.datetime and PyDateTime_CheckExact(o):
+                if datetime_tzinfo(o) is None:
+                    PyErr_Format(ValueError, b"can not serialize '%.200s' object where tzinfo=None", Py_TYPE(o).tp_name)
                 delta = o - epoch
                 if not PyDelta_CheckExact(delta):
                     raise ValueError("failed to calculate delta")

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -274,9 +274,7 @@ cdef class Packer(object):
                 if ret == 0:
                     ret = msgpack_pack_raw_body(&self.pk, <char*>view.buf, L)
                 PyBuffer_Release(&view);
-            elif self.datetime and PyDateTime_CheckExact(o):
-                if datetime_tzinfo(o) is None:
-                    PyErr_Format(ValueError, b"can not serialize '%.200s' object where tzinfo=None", Py_TYPE(o).tp_name)
+            elif self.datetime and PyDateTime_CheckExact(o) and datetime_tzinfo(o) is not None:
                 delta = o - epoch
                 if not PyDelta_CheckExact(delta):
                     raise ValueError("failed to calculate delta")
@@ -287,6 +285,8 @@ cdef class Packer(object):
                 o = self._default(o)
                 default_used = 1
                 continue
+            elif self.datetime and PyDateTime_CheckExact(o):
+                PyErr_Format(ValueError, b"can not serialize '%.200s' object where tzinfo=None", Py_TYPE(o).tp_name)
             else:
                 PyErr_Format(TypeError, b"can not serialize '%.200s' object", Py_TYPE(o).tp_name)
             return ret

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -865,9 +865,7 @@ class Packer(object):
                     len(obj), dict_iteritems(obj), nest_limit - 1
                 )
 
-            if self._datetime and check(obj, _DateTime):
-                if obj.tzinfo is None:
-                    raise ValueError("Cannot serialize %r where tzinfo=None" % (obj,))
+            if self._datetime and check(obj, _DateTime) and obj.tzinfo is not None:
                 obj = Timestamp.from_datetime(obj)
                 default_used = 1
                 continue
@@ -876,6 +874,10 @@ class Packer(object):
                 obj = self._default(obj)
                 default_used = 1
                 continue
+
+            if self._datetime and check(obj, _DateTime):
+                raise ValueError("Cannot serialize %r where tzinfo=None" % (obj,))
+
             raise TypeError("Cannot serialize %r" % (obj,))
 
     def pack(self, obj):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -865,7 +865,9 @@ class Packer(object):
                     len(obj), dict_iteritems(obj), nest_limit - 1
                 )
 
-            if self._datetime and check(obj, _DateTime) and obj.tzinfo is not None:
+            if self._datetime and check(obj, _DateTime):
+                if obj.tzinfo is None:
+                    raise ValueError("Cannot serialize %r where tzinfo=None" % (obj,))
                 obj = Timestamp.from_datetime(obj)
                 default_used = 1
                 continue

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -140,3 +140,14 @@ def test_issue451():
 
     unpacked = msgpack.unpackb(packed, timestamp=3)
     assert dt == unpacked
+
+@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
+def test_pack_datetime_without_tzinfo():
+    dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14)
+    with pytest.raises(ValueError, match="where tzinfo=None"):
+        packed = msgpack.packb(dt, datetime=True)
+
+    dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14, tzinfo=_utc)
+    packed = msgpack.packb(dt, datetime=True)
+    unpacked = msgpack.unpackb(packed, timestamp=3)
+    assert unpacked == dt

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -148,6 +148,10 @@ def test_pack_datetime_without_tzinfo():
     with pytest.raises(ValueError, match="where tzinfo=None"):
         packed = msgpack.packb(dt, datetime=True)
 
+    dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14)
+    packed = msgpack.packb(dt, datetime=True, default=lambda x: None)
+    assert packed == msgpack.packb(None)
+
     dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14, tzinfo=_utc)
     packed = msgpack.packb(dt, datetime=True)
     unpacked = msgpack.unpackb(packed, timestamp=3)

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -141,6 +141,7 @@ def test_issue451():
     unpacked = msgpack.unpackb(packed, timestamp=3)
     assert dt == unpacked
 
+
 @pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_pack_datetime_without_tzinfo():
     dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14)


### PR DESCRIPTION
When attempting to pack a `datetime.datetime` object with `msgpack.packb(dt, datetime=True)` where the `dt` object is missing `tzinfo`, the library throws the generic error `TypeError: can not serialize 'datetime.datetime' object`.

That threw me off as I thought the problem related to `datetime=True`, and didn't realise I was missing `tzinfo`. This small patch outputs a more specific error message for that edge case.
