### PR TITLE
Make pure-python wheels and eggs possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ else:
     macros = [("__LITTLE_ENDIAN__", "1")]
 
 ext_modules = []
-if not PYPY and not PY2:
+if not PYPY and not PY2 and not os.environ.get("MSGPACK_PUREPYTHON"):
     ext_modules.append(
         Extension(
             "msgpack._cmsgpack",


### PR DESCRIPTION
`msgpack-python` has an optional C extension. Sometimes people may want to build a wheel or an egg that can be used on all platforms and has the appropriate metadata (eg `py3-none-any` wheel). Example: https://github.com/ionrock/cachecontrol/issues/160. With this little addition to setup.py I can build `msgpack-1.0.2-py3.9.egg` like this:
```sh
MSGPACK_PUREPYTHON=1 ./setup.py bdist_egg
```