### PR TITLE
cimport uint64_t instead of using ctypedef

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -8,7 +8,7 @@ cdef extern from "Python.h":
 from libc.stdlib cimport *
 from libc.string cimport *
 from libc.limits cimport *
-ctypedef unsigned long long uint64_t
+from libc.stdint cimport uint64_t
 
 from .exceptions import (
     BufferFull,


### PR DESCRIPTION
Cython already has its out [internal definition](https://github.com/cython/cython/blob/0.29.x/Cython/Includes/libc/stdint.pxd#L16) of `uint64_t` so it might as well  be used here. In addition `ctypedef` causes a build break if `msgpack` is compiled with Cython3.