### PR TITLE
Clearify unpack exception related to key type and strict_map_key flag

### DIFF
--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -193,7 +193,7 @@ static inline int unpack_callback_map(unpack_user* u, unsigned int n, msgpack_un
 static inline int unpack_callback_map_item(unpack_user* u, unsigned int current, msgpack_unpack_object* c, msgpack_unpack_object k, msgpack_unpack_object v)
 {
     if (u->strict_map_key && !PyUnicode_CheckExact(k) && !PyBytes_CheckExact(k)) {
-        PyErr_Format(PyExc_ValueError, "%.100s is not allowed for map key", Py_TYPE(k)->tp_name);
+        PyErr_Format(PyExc_ValueError, "%.100s is not allowed for map key when strict_map_key=True", Py_TYPE(k)->tp_name);
         return -1;
     }
     if (PyUnicode_CheckExact(k)) {


### PR DESCRIPTION
It took me a while to figure out that the strict_map_key flag was involved in the generation of this exception. Even though the readme mentions the behaviour, it would be nice to make the exception message more explicit.