### PR TITLE
Do not fail silently when unpacking large messages

### DIFF
--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 import sys
-from msgpack import Unpacker, packb, OutOfData, ExtType
+from msgpack import Unpacker, pack, packb, OutOfData, ExtType
 from pytest import raises, mark
 
 try:
@@ -90,3 +90,20 @@ def test_unpacker_tell_read_bytes():
         assert obj == unp
         assert pos == unpacker.tell()
         assert unpacker.read_bytes(n) == raw
+
+
+def test_unpacker_raise_max_buffer_size():
+    max_buffer_size = 1024
+    small_value = b"a" * max_buffer_size
+
+    f = BytesIO()
+    pack(small_value, f)
+    f.seek(0)
+    assert list(Unpacker(f, max_buffer_size=max_buffer_size)) == [small_value]
+
+    large_value = b"a" * (max_buffer_size + 1)
+    f = BytesIO()
+    pack(large_value, f)
+    f.seek(0)
+    with raises(ValueError):
+        list(Unpacker(f, max_buffer_size=max_buffer_size))


### PR DESCRIPTION
Fixes #503

Raising ValueError matches the behaviour of the pure Python version.
I'm not sure that this is the best place to raise this message; it might
make more sense when reading headers or in `append_buffer` or
something. It's also possible that we want to raise BufferFull instead
of ValueError.