### PR TITLE
Fallback to compiler defines when __BYTE_ORDER is not available

### DIFF
--- a/msgpack/sysdep.h
+++ b/msgpack/sysdep.h
@@ -61,8 +61,6 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 #endif
 
-#else
-#include <arpa/inet.h>  /* __BYTE_ORDER */
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)

--- a/msgpack/sysdep.h
+++ b/msgpack/sysdep.h
@@ -66,6 +66,15 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+/*
+ * __BYTE_ORDER, __LITTLE_ENDIAN and __BIG_ENDIAN are nonstandard and not
+ * always available. In those cases, fallback to common compiler defines.
+ */
+#if !defined(__BYTE_ORDER)
+#define __BYTE_ORDER __BYTE_ORDER__
+#define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#endif
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define __LITTLE_ENDIAN__
 #elif __BYTE_ORDER == __BIG_ENDIAN

--- a/msgpack/sysdep.h
+++ b/msgpack/sysdep.h
@@ -66,18 +66,9 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-/*
- * __BYTE_ORDER, __LITTLE_ENDIAN and __BIG_ENDIAN are nonstandard and not
- * always available. In those cases, fallback to common compiler defines.
- */
-#if !defined(__BYTE_ORDER)
-#define __BYTE_ORDER __BYTE_ORDER__
-#define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
-#define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
-#endif
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define __LITTLE_ENDIAN__
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define __BIG_ENDIAN__
 #elif _WIN32
 #define __LITTLE_ENDIAN__


### PR DESCRIPTION
On some systems (I tested it on Oracle Solaris and FreeBSD),  `__BYTE_ORDER`, `__LITTLE_ENDIAN` and `__BIG_ENDIAN` from `arpa/inet.h` are not available, which can cause failures on big endian systems (because little endian is the default). This adds a fallback to common compiler defines in those cases.

Addresses issues raised in #495.