### PR TITLE
Drop python2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ and `raw=True` options.
 
 ```pycon
 >>> import msgpack
->>> msgpack.unpackb(msgpack.packb([b'spam', u'eggs'], use_bin_type=False), raw=True)
+>>> msgpack.unpackb(msgpack.packb([b'spam', 'eggs'], use_bin_type=False), raw=True)
 [b'spam', b'eggs']
->>> msgpack.unpackb(msgpack.packb([b'spam', u'eggs'], use_bin_type=True), raw=False)
+>>> msgpack.unpackb(msgpack.packb([b'spam', 'eggs'], use_bin_type=True), raw=False)
 [b'spam', 'eggs']
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"msgpack"
-copyright = u"Inada Naoki"
+project = "msgpack"
+copyright = "Inada Naoki"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -181,7 +181,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "msgpack.tex", u"msgpack Documentation", u"Author", "manual"),
+    ("index", "msgpack.tex", "msgpack Documentation", "Author", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -209,7 +209,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "msgpack", u"msgpack Documentation", [u"Author"], 1)]
+man_pages = [("index", "msgpack", "msgpack Documentation", ["Author"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -224,8 +224,8 @@ texinfo_documents = [
     (
         "index",
         "msgpack",
-        u"msgpack Documentation",
-        u"Author",
+        "msgpack Documentation",
+        "Author",
         "msgpack",
         "One line description of project.",
         "Miscellaneous",
@@ -245,10 +245,10 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u"msgpack"
-epub_author = u"Author"
-epub_publisher = u"Author"
-epub_copyright = u"2013, Author"
+epub_title = "msgpack"
+epub_author = "Author"
+epub_publisher = "Author"
+epub_copyright = "2013, Author"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -10,7 +10,7 @@ version = (1, 0, 4)
 __version__ = "1.0.4"
 
 
-if os.environ.get("MSGPACK_PUREPYTHON") or sys.version_info[0] == 2:
+if os.environ.get("MSGPACK_PUREPYTHON"):
     from .fallback import Packer, unpackb, Unpacker
 else:
     try:

--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -98,7 +98,6 @@ cdef class Packer(object):
         If set to true, datetime with tzinfo is packed into Timestamp type.
         Note that the tzinfo is stripped in the timestamp.
         You can get UTC datetime with `timestamp=3` option of the Unpacker.
-        (Python 2 is not supported).
 
     :param str unicode_errors:
         The error handler for encoding unicode. (default: 'strict')

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -236,7 +236,7 @@ cdef class Unpacker(object):
             0 - Timestamp
             1 - float  (Seconds from the EPOCH)
             2 - int  (Nanoseconds from the EPOCH)
-            3 - datetime.datetime  (UTC).  Python 2 is not supported.
+            3 - datetime.datetime  (UTC).
 
     :param bool strict_map_key:
         If true (default), only str or bytes are accepted for map (dict) keys.

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -164,8 +164,6 @@ class Timestamp(object):
     def to_datetime(self):
         """Get the timestamp as a UTC datetime.
 
-        Python 2 is not supported.
-
         :rtype: datetime.
         """
         utc = datetime.timezone.utc
@@ -176,8 +174,6 @@ class Timestamp(object):
     @staticmethod
     def from_datetime(dt):
         """Create a Timestamp from datetime with tzinfo.
-
-        Python 2 is not supported.
 
         :rtype: Timestamp
         """

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -5,7 +5,6 @@ import sys
 import struct
 
 
-int_types = int
 try:
     _utc = datetime.timezone.utc
 except AttributeError:
@@ -49,9 +48,9 @@ class Timestamp(object):
 
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
-        if not isinstance(seconds, int_types):
+        if not isinstance(seconds, int):
             raise TypeError("seconds must be an interger")
-        if not isinstance(nanoseconds, int_types):
+        if not isinstance(nanoseconds, int):
             raise TypeError("nanoseconds must be an integer")
         if not (0 <= nanoseconds < 10**9):
             raise ValueError(

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -5,9 +5,6 @@ import sys
 import struct
 
 
-_utc = datetime.timezone.utc
-
-
 class ExtType(namedtuple("ExtType", "code data")):
     """ExtType represents ext type in msgpack."""
 

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -168,7 +168,8 @@ class Timestamp(object):
 
         :rtype: datetime.
         """
-        return datetime.datetime.fromtimestamp(0, _utc) + datetime.timedelta(
+        utc = datetime.timezone.utc
+        return datetime.datetime.fromtimestamp(0, utc) + datetime.timedelta(
             seconds=self.to_unix()
         )
 

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -5,17 +5,11 @@ import sys
 import struct
 
 
-PY2 = sys.version_info[0] == 2
-
-if PY2:
-    int_types = (int, long)
-    _utc = None
-else:
-    int_types = int
-    try:
-        _utc = datetime.timezone.utc
-    except AttributeError:
-        _utc = datetime.timezone(datetime.timedelta(0))
+int_types = int
+try:
+    _utc = datetime.timezone.utc
+except AttributeError:
+    _utc = datetime.timezone(datetime.timedelta(0))
 
 
 class ExtType(namedtuple("ExtType", "code data")):

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -46,7 +46,7 @@ class Timestamp(object):
         Note: Negative times (before the UNIX epoch) are represented as negative seconds + positive ns.
         """
         if not isinstance(seconds, int):
-            raise TypeError("seconds must be an interger")
+            raise TypeError("seconds must be an integer")
         if not isinstance(nanoseconds, int):
             raise TypeError("nanoseconds must be an integer")
         if not (0 <= nanoseconds < 10**9):

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -5,10 +5,7 @@ import sys
 import struct
 
 
-try:
-    _utc = datetime.timezone.utc
-except AttributeError:
-    _utc = datetime.timezone(datetime.timedelta(0))
+_utc = datetime.timezone.utc
 
 
 class ExtType(namedtuple("ExtType", "code data")):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -177,7 +177,7 @@ class Unpacker(object):
             0 - Timestamp
             1 - float  (Seconds from the EPOCH)
             2 - int  (Nanoseconds from the EPOCH)
-            3 - datetime.datetime  (UTC).  Python 2 is not supported.
+            3 - datetime.datetime  (UTC).
 
     :param bool strict_map_key:
         If true (default), only str or bytes are accepted for map (dict) keys.
@@ -673,7 +673,6 @@ class Packer(object):
         If set to true, datetime with tzinfo is packed into Timestamp type.
         Note that the tzinfo is stripped in the timestamp.
         You can get UTC datetime with `timestamp=3` option of the Unpacker.
-        (Python 2 is not supported).
 
     :param str unicode_errors:
         The error handler for encoding unicode. (default: 'strict')

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -831,9 +831,7 @@ class Packer(object):
                     self._pack(obj[i], nest_limit - 1)
                 return
             if check(obj, dict):
-                return self._pack_map_pairs(
-                    len(obj), obj.items(), nest_limit - 1
-                )
+                return self._pack_map_pairs(len(obj), obj.items(), nest_limit - 1)
 
             if self._datetime and check(obj, _DateTime) and obj.tzinfo is not None:
                 obj = Timestamp.from_datetime(obj)

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -4,20 +4,12 @@ import sys
 import struct
 
 
-PY2 = sys.version_info[0] == 2
-if PY2:
-    int_types = (int, long)
+int_types = int
+unicode = str
+xrange = range
 
-    def dict_iteritems(d):
-        return d.iteritems()
-
-else:
-    int_types = int
-    unicode = str
-    xrange = range
-
-    def dict_iteritems(d):
-        return d.items()
+def dict_iteritems(d):
+    return d.items()
 
 
 if sys.version_info < (3, 5):
@@ -134,14 +126,7 @@ def unpackb(packed, **kwargs):
     return ret
 
 
-if sys.version_info < (2, 7, 6):
-
-    def _unpack_from(f, b, o=0):
-        """Explicit type cast for legacy struct.unpack_from"""
-        return struct.unpack_from(f, bytes(b), o)
-
-else:
-    _unpack_from = struct.unpack_from
+_unpack_from = struct.unpack_from
 
 _NO_FORMAT_USED = ""
 _MSGPACK_HEADERS = {
@@ -585,7 +570,7 @@ class Unpacker(object):
                         raise ValueError(
                             "%s is not allowed for map key" % str(type(key))
                         )
-                    if not PY2 and type(key) is str:
+                    if type(key) is str:
                         key = sys.intern(key)
                     ret[key] = self._unpack(EX_CONSTRUCT)
                 if self._object_hook is not None:
@@ -743,8 +728,6 @@ class Packer(object):
         self._autoreset = autoreset
         self._use_bin_type = use_bin_type
         self._buffer = StringIO()
-        if PY2 and datetime:
-            raise ValueError("datetime is not supported in Python 2")
         self._datetime = bool(datetime)
         self._unicode_errors = unicode_errors or "strict"
         if default is not None:
@@ -1004,7 +987,7 @@ class Packer(object):
 
     def getbuffer(self):
         """Return view of internal buffer."""
-        if USING_STRINGBUILDER or PY2:
+        if USING_STRINGBUILDER:
             return memoryview(self.bytes())
         else:
             return self._buffer.getbuffer()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from setuptools.command.sdist import sdist
 
 
 PYPY = hasattr(sys, "pypy_version_info")
-PY2 = sys.version_info[0] == 2
 
 
 class NoCython(Exception):
@@ -79,7 +78,7 @@ if sys.platform == "win32":
     macros = [("__LITTLE_ENDIAN__", "1")]
 
 ext_modules = []
-if not PYPY and not PY2 and not os.environ.get("MSGPACK_PUREPYTHON"):
+if not PYPY and not os.environ.get("MSGPACK_PUREPYTHON"):
     ext_modules.append(
         Extension(
             "msgpack._cmsgpack",

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -6,7 +6,6 @@ import pytest
 from msgpack import packb, unpackb
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="Python 2 is not supported")
 def test_unpack_buffer():
     from array import array
 

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -134,4 +134,4 @@ def test_match():
 
 
 def test_unicode():
-    assert unpackb(packb(u"foobar"), use_list=1) == u"foobar"
+    assert unpackb(packb("foobar"), use_list=1) == "foobar"

--- a/test/test_except.py
+++ b/test/test_except.py
@@ -53,7 +53,7 @@ def test_invalidvalue():
 
 
 def test_strict_map_key():
-    valid = {u"unicode": 1, b"bytes": 2}
+    valid = {"unicode": 1, b"bytes": 2}
     packed = packb(valid, use_bin_type=True)
     assert valid == unpackb(packed, raw=False, strict_map_key=True)
 

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -64,17 +64,14 @@ def test_extension_type():
     assert obj == obj2
 
 
-long = int
-
-
 def test_overriding_hooks():
     def default(obj):
-        if isinstance(obj, long):
+        if isinstance(obj, int):
             return {"__type__": "long", "__data__": str(obj)}
         else:
             return obj
 
-    obj = {"testval": long(1823746192837461928374619)}
+    obj = {"testval": 1823746192837461928374619}
     refobj = {"testval": default(obj["testval"])}
     refout = msgpack.packb(refobj)
     assert isinstance(refout, (str, bytes))

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -55,10 +55,7 @@ def test_extension_type():
         print("ext_hook called", code, data)
         assert code == 123
         obj = array.array("d")
-        try:
-            obj.frombytes(data)
-        except AttributeError:  # PY2
-            obj.fromstring(data)
+        obj.frombytes(data)
         return obj
 
     obj = [42, b"hello", array.array("d", [1.1, 2.2, 3.3])]
@@ -67,10 +64,7 @@ def test_extension_type():
     assert obj == obj2
 
 
-import sys
-
-if sys.version > "3":
-    long = int
+long = int
 
 
 def test_overriding_hooks():

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -7,7 +7,6 @@ from msgpack import packb, unpackb
 import sys
 
 
-
 def make_array(f, data):
     a = array(f)
     a.frombytes(data)

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -7,10 +7,6 @@ from msgpack import packb, unpackb
 import sys
 
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info[0] < 3, reason="Only Python 3 supports buffer protocol"
-)
-
 
 def make_array(f, data):
     a = array(f)

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -80,9 +80,6 @@ def testPackByteArrays():
         check(td)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0), reason="Python 2 passes invalid surrogates"
-)
 def testIgnoreUnicodeErrors():
     re = unpackb(
         packb(b"abc\xeddef", use_bin_type=False), raw=False, unicode_errors="ignore"
@@ -96,9 +93,6 @@ def testStrictUnicodeUnpack():
         unpackb(packed, raw=False, use_list=1)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0), reason="Python 2 passes invalid surrogates"
-)
 def testIgnoreErrorsPack():
     re = unpackb(
         packb("abc\uDC80\uDCFFdef", use_bin_type=True, unicode_errors="ignore"),

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -2,7 +2,7 @@ import pytest
 import sys
 import datetime
 import msgpack
-from msgpack.ext import Timestamp, _utc
+from msgpack.ext import Timestamp
 
 
 def test_timestamp():
@@ -84,18 +84,21 @@ def test_timestamp_to():
 
 def test_timestamp_datetime():
     t = Timestamp(42, 14)
-    assert t.to_datetime() == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=_utc)
+    utc = datetime.timezone.utc
+    assert t.to_datetime() == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=utc)
 
 
 def test_unpack_datetime():
     t = Timestamp(42, 14)
+    utc = datetime.timezone.utc
     packed = msgpack.packb(t)
     unpacked = msgpack.unpackb(packed, timestamp=3)
-    assert unpacked == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=_utc)
+    assert unpacked == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=utc)
 
 
 def test_pack_unpack_before_epoch():
-    t_in = datetime.datetime(1960, 1, 1, tzinfo=_utc)
+    utc = datetime.timezone.utc
+    t_in = datetime.datetime(1960, 1, 1, tzinfo=utc)
     packed = msgpack.packb(t_in, datetime=True)
     unpacked = msgpack.unpackb(packed, timestamp=3)
     assert unpacked == t_in
@@ -104,7 +107,8 @@ def test_pack_unpack_before_epoch():
 def test_pack_datetime():
     t = Timestamp(42, 14000)
     dt = t.to_datetime()
-    assert dt == datetime.datetime(1970, 1, 1, 0, 0, 42, 14, tzinfo=_utc)
+    utc = datetime.timezone.utc
+    assert dt == datetime.datetime(1970, 1, 1, 0, 0, 42, 14, tzinfo=utc)
 
     packed = msgpack.packb(dt, datetime=True)
     packed2 = msgpack.packb(t)
@@ -126,7 +130,8 @@ def test_pack_datetime():
 
 def test_issue451():
     # https://github.com/msgpack/msgpack-python/issues/451
-    dt = datetime.datetime(2100, 1, 1, 1, 1, tzinfo=_utc)
+    utc = datetime.timezone.utc
+    dt = datetime.datetime(2100, 1, 1, 1, 1, tzinfo=utc)
     packed = msgpack.packb(dt, datetime=True)
     assert packed == b"\xd6\xff\xf4\x86eL"
 
@@ -143,7 +148,8 @@ def test_pack_datetime_without_tzinfo():
     packed = msgpack.packb(dt, datetime=True, default=lambda x: None)
     assert packed == msgpack.packb(None)
 
-    dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14, tzinfo=_utc)
+    utc = datetime.timezone.utc
+    dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14, tzinfo=utc)
     packed = msgpack.packb(dt, datetime=True)
     unpacked = msgpack.unpackb(packed, timestamp=3)
     assert unpacked == dt

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -85,13 +85,11 @@ def test_timestamp_to():
     assert t.to_unix_nano() == 42000014000
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_timestamp_datetime():
     t = Timestamp(42, 14)
     assert t.to_datetime() == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=_utc)
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_unpack_datetime():
     t = Timestamp(42, 14)
     packed = msgpack.packb(t)
@@ -99,7 +97,6 @@ def test_unpack_datetime():
     assert unpacked == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=_utc)
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_pack_unpack_before_epoch():
     t_in = datetime.datetime(1960, 1, 1, tzinfo=_utc)
     packed = msgpack.packb(t_in, datetime=True)
@@ -107,7 +104,6 @@ def test_pack_unpack_before_epoch():
     assert unpacked == t_in
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_pack_datetime():
     t = Timestamp(42, 14000)
     dt = t.to_datetime()
@@ -131,7 +127,6 @@ def test_pack_datetime():
     assert msgpack.unpackb(packed) is None
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_issue451():
     # https://github.com/msgpack/msgpack-python/issues/451
     dt = datetime.datetime(2100, 1, 1, 1, 1, tzinfo=_utc)
@@ -142,7 +137,6 @@ def test_issue451():
     assert dt == unpacked
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="datetime support is PY3+ only")
 def test_pack_datetime_without_tzinfo():
     dt = datetime.datetime(1970, 1, 1, 0, 0, 42, 14)
     with pytest.raises(ValueError, match="where tzinfo=None"):

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -2,8 +2,7 @@ import pytest
 import sys
 import datetime
 import msgpack
-from msgpack.ext import Timestamp
-from msgpack.ext import _utc
+from msgpack.ext import Timestamp, _utc
 
 
 def test_timestamp():

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -3,9 +3,7 @@ import sys
 import datetime
 import msgpack
 from msgpack.ext import Timestamp
-
-if sys.version_info[0] > 2:
-    from msgpack.ext import _utc
+from msgpack.ext import _utc
 
 
 def test_timestamp():

--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -70,7 +70,7 @@ def test_unpacker_ext_hook():
 
 
 def test_unpacker_tell():
-    objects = 1, 2, u"abc", u"def", u"ghi"
+    objects = 1, 2, "abc", "def", "ghi"
     packed = b"\x01\x02\xa3abc\xa3def\xa3ghi"
     positions = 1, 2, 6, 10, 14
     unpacker = Unpacker(BytesIO(packed))
@@ -80,7 +80,7 @@ def test_unpacker_tell():
 
 
 def test_unpacker_tell_read_bytes():
-    objects = 1, u"abc", u"ghi"
+    objects = 1, "abc", "ghi"
     packed = b"\x01\x02\xa3abc\xa3def\xa3ghi"
     raw_data = b"\x02", b"\xa3def", b""
     lenghts = 1, 4, 999

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 envlist =
-    py27-pure,
     {py35,py36,py37,py38}-{c,pure},
     {pypy,pypy3}-pure,
-    py27-x86,
     py34-x86,
 isolated_build = true
 
@@ -18,17 +16,6 @@ commands=
     pure: py.test
 setenv=
     pure: MSGPACK_PUREPYTHON=x
-
-[testenv:py27-x86]
-basepython=python2.7-x86
-deps=
-    pytest
-
-changedir=test
-commands=
-    python -c 'import sys; print(hex(sys.maxsize))'
-    python -c 'from msgpack import _cmsgpack'
-    py.test
 
 [testenv:py34-x86]
 basepython=python3.4-x86


### PR DESCRIPTION
The PR removes python2 references and cases.
`tox` command is green on cpython3.9 (py39-c and py39-pure) on my local machine.


Close #518