### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+PYTHON_SOURCES = msgpack test setup.py
+
 .PHONY: all
 all: cython
 	python setup.py build_ext -i -f
 
 .PHONY: black
 black:
-	black -S msgpack/ test/ setup.py
+	black $(PYTHON_SOURCES)
 
 .PHONY: cython
 cython:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ all: cython
 black:
 	black $(PYTHON_SOURCES)
 
+.PHONY: pyupgrade
+pyupgrade:
+	@find $(PYTHON_SOURCES) -name '*.py' -type f -exec pyupgrade --py37-plus '{}' \;
+
 .PHONY: cython
 cython:
 	cython --cplus msgpack/_cmsgpack.pyx

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from .exceptions import *
 from .ext import ExtType, Timestamp
 

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from collections import namedtuple
 import datetime
 import sys
@@ -15,10 +14,10 @@ class ExtType(namedtuple("ExtType", "code data")):
             raise TypeError("data must be bytes")
         if not 0 <= code <= 127:
             raise ValueError("code must be 0~127")
-        return super(ExtType, cls).__new__(cls, code, data)
+        return super().__new__(cls, code, data)
 
 
-class Timestamp(object):
+class Timestamp:
     """Timestamp represents the Timestamp extension type in msgpack.
 
     When built with Cython, msgpack uses C methods to pack and unpack `Timestamp`. When using pure-Python
@@ -53,7 +52,7 @@ class Timestamp(object):
 
     def __repr__(self):
         """String representation of Timestamp."""
-        return "Timestamp(seconds={0}, nanoseconds={1})".format(self.seconds, self.nanoseconds)
+        return f"Timestamp(seconds={self.seconds}, nanoseconds={self.nanoseconds})"
 
     def __eq__(self, other):
         """Check for equality with another Timestamp object"""

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -47,24 +47,18 @@ class Timestamp(object):
         if not isinstance(nanoseconds, int):
             raise TypeError("nanoseconds must be an integer")
         if not (0 <= nanoseconds < 10**9):
-            raise ValueError(
-                "nanoseconds must be a non-negative integer less than 999999999."
-            )
+            raise ValueError("nanoseconds must be a non-negative integer less than 999999999.")
         self.seconds = seconds
         self.nanoseconds = nanoseconds
 
     def __repr__(self):
         """String representation of Timestamp."""
-        return "Timestamp(seconds={0}, nanoseconds={1})".format(
-            self.seconds, self.nanoseconds
-        )
+        return "Timestamp(seconds={0}, nanoseconds={1})".format(self.seconds, self.nanoseconds)
 
     def __eq__(self, other):
         """Check for equality with another Timestamp object"""
         if type(other) is self.__class__:
-            return (
-                self.seconds == other.seconds and self.nanoseconds == other.nanoseconds
-            )
+            return self.seconds == other.seconds and self.nanoseconds == other.nanoseconds
         return False
 
     def __ne__(self, other):
@@ -164,9 +158,7 @@ class Timestamp(object):
         :rtype: datetime.
         """
         utc = datetime.timezone.utc
-        return datetime.datetime.fromtimestamp(0, utc) + datetime.timedelta(
-            seconds=self.to_unix()
-        )
+        return datetime.datetime.fromtimestamp(0, utc) + datetime.timedelta(seconds=self.to_unix())
 
     @staticmethod
     def from_datetime(dt):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -334,9 +334,7 @@ class Unpacker(object):
         if object_pairs_hook is not None and not callable(object_pairs_hook):
             raise TypeError("`object_pairs_hook` is not callable")
         if object_hook is not None and object_pairs_hook is not None:
-            raise TypeError(
-                "object_pairs_hook and object_hook are mutually " "exclusive"
-            )
+            raise TypeError("object_pairs_hook and object_hook are mutually " "exclusive")
         if not callable(ext_hook):
             raise TypeError("`ext_hook` is not callable")
 
@@ -434,9 +432,7 @@ class Unpacker(object):
             n = b & 0b00001111
             typ = TYPE_ARRAY
             if n > self._max_array_len:
-                raise ValueError(
-                    "%s exceeds max_array_len(%s)" % (n, self._max_array_len)
-                )
+                raise ValueError("%s exceeds max_array_len(%s)" % (n, self._max_array_len))
         elif b & 0b11110000 == 0b10000000:
             n = b & 0b00001111
             typ = TYPE_MAP
@@ -478,9 +474,7 @@ class Unpacker(object):
         elif 0xD4 <= b <= 0xD8:
             size, fmt, typ = _MSGPACK_HEADERS[b]
             if self._max_ext_len < size:
-                raise ValueError(
-                    "%s exceeds max_ext_len(%s)" % (size, self._max_ext_len)
-                )
+                raise ValueError("%s exceeds max_ext_len(%s)" % (size, self._max_ext_len))
             self._reserve(size + 1)
             n, obj = struct.unpack_from(fmt, self._buffer, self._buff_i)
             self._buff_i += size + 1
@@ -501,9 +495,7 @@ class Unpacker(object):
             (n,) = struct.unpack_from(fmt, self._buffer, self._buff_i)
             self._buff_i += size
             if n > self._max_array_len:
-                raise ValueError(
-                    "%s exceeds max_array_len(%s)" % (n, self._max_array_len)
-                )
+                raise ValueError("%s exceeds max_array_len(%s)" % (n, self._max_array_len))
         elif 0xDE <= b <= 0xDF:
             size, fmt, typ = _MSGPACK_HEADERS[b]
             self._reserve(size)
@@ -549,17 +541,14 @@ class Unpacker(object):
                 return
             if self._object_pairs_hook is not None:
                 ret = self._object_pairs_hook(
-                    (self._unpack(EX_CONSTRUCT), self._unpack(EX_CONSTRUCT))
-                    for _ in range(n)
+                    (self._unpack(EX_CONSTRUCT), self._unpack(EX_CONSTRUCT)) for _ in range(n)
                 )
             else:
                 ret = {}
                 for _ in range(n):
                     key = self._unpack(EX_CONSTRUCT)
                     if self._strict_map_key and type(key) not in (str, bytes):
-                        raise ValueError(
-                            "%s is not allowed for map key" % str(type(key))
-                        )
+                        raise ValueError("%s is not allowed for map key" % str(type(key)))
                     if type(key) is str:
                         key = sys.intern(key)
                     ret[key] = self._unpack(EX_CONSTRUCT)
@@ -933,7 +922,7 @@ class Packer(object):
 
     def _pack_map_pairs(self, n, pairs, nest_limit=DEFAULT_RECURSE_LIMIT):
         self._pack_map_header(n)
-        for (k, v) in pairs:
+        for k, v in pairs:
             self._pack(k, nest_limit - 1)
             self._pack(v, nest_limit - 1)
 

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -315,7 +315,7 @@ class Unpacker:
         if object_pairs_hook is not None and not callable(object_pairs_hook):
             raise TypeError("`object_pairs_hook` is not callable")
         if object_hook is not None and object_pairs_hook is not None:
-            raise TypeError("object_pairs_hook and object_hook are mutually " "exclusive")
+            raise TypeError("object_pairs_hook and object_hook are mutually exclusive")
         if not callable(ext_hook):
             raise TypeError("`ext_hook` is not callable")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ requires = [
     "setuptools >= 35.0.2",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 100
+target-version = ["py37"]
+skip_string_normalization = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Cython~=0.29.30
 # Tools required only for development. No need to add it to pyproject.toml file.
 black==23.3.0
 pytest==7.3.1
-pyupgrade==3.4.0
+pyupgrade==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Cython~=0.29.30
 
 # Tools required only for development. No need to add it to pyproject.toml file.
 black==23.3.0
+pyupgrade==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# Also declared in pyproject.toml, if updating here please also update there
+# Also declared in pyproject.toml, if updating here please also update there.
 Cython~=0.29.30
 
-# dev only tools. no need to add pyproject
-black==22.3.0
+# Tools required only for development. No need to add it to pyproject.toml file.
+black==23.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ Cython~=0.29.30
 
 # Tools required only for development. No need to add it to pyproject.toml file.
 black==23.3.0
+pytest==7.3.1
 pyupgrade==3.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ project_urls =
 
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 import io
 import os
 import sys
@@ -25,7 +24,7 @@ except ImportError:
 
 
 def cythonize(src):
-    sys.stderr.write("cythonize: %r\n" % (src,))
+    sys.stderr.write(f"cythonize: {src!r}\n")
     cython_compiler.compile([src], cplus=True)
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,7 @@ def ensure_source(src):
         if not have_cython:
             raise NoCython
         cythonize(pyx)
-    elif (
-        os.path.exists(pyx)
-        and os.stat(src).st_mtime < os.stat(pyx).st_mtime
-        and have_cython
-    ):
+    elif os.path.exists(pyx) and os.stat(src).st_mtime < os.stat(pyx).st_mtime and have_cython:
         cythonize(pyx)
     return src
 

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import sys
 import pytest

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-# coding: utf-8
 from msgpack import packb, unpackb
 
 
 def check(length, obj, use_bin_type=True):
     v = packb(obj, use_bin_type=use_bin_type)
-    assert len(v) == length, "%r length should be %r but get %r" % (obj, length, len(v))
+    assert len(v) == length, f"{obj!r} length should be {length!r} but get {len(v)!r}"
     assert unpackb(v, use_list=0, raw=not use_bin_type) == obj
 
 
@@ -120,11 +119,11 @@ def test_match():
         ),
         ({}, b"\x80"),
         (
-            dict([(x, x) for x in range(15)]),
+            {x: x for x in range(15)},
             b"\x8f\x00\x00\x01\x01\x02\x02\x03\x03\x04\x04\x05\x05\x06\x06\x07\x07\x08\x08\t\t\n\n\x0b\x0b\x0c\x0c\r\r\x0e\x0e",
         ),
         (
-            dict([(x, x) for x in range(16)]),
+            {x: x for x in range(16)},
             b"\xde\x00\x10\x00\x00\x01\x01\x02\x02\x03\x03\x04\x04\x05\x05\x06\x06\x07\x07\x08\x08\t\t\n\n\x0b\x0b\x0c\x0c\r\r\x0e\x0e\x0f\x0f",
         ),
     ]

--- a/test/test_except.py
+++ b/test/test_except.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 from pytest import raises
 from msgpack import packb, unpackb, Unpacker, FormatError, StackError, OutOfData

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -17,9 +17,7 @@ def test_pack_ext_type():
     assert p(b"A" * 16) == b"\xd8\x42" + b"A" * 16  # fixext 16
     assert p(b"ABC") == b"\xc7\x03\x42ABC"  # ext 8
     assert p(b"A" * 0x0123) == b"\xc8\x01\x23\x42" + b"A" * 0x0123  # ext 16
-    assert (
-        p(b"A" * 0x00012345) == b"\xc9\x00\x01\x23\x45\x42" + b"A" * 0x00012345
-    )  # ext 32
+    assert p(b"A" * 0x00012345) == b"\xc9\x00\x01\x23\x45\x42" + b"A" * 0x00012345  # ext 32
 
 
 def test_unpack_ext_type():

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import array
 import msgpack
 from msgpack import ExtType
@@ -47,7 +46,7 @@ def test_extension_type():
             except AttributeError:
                 data = obj.tostring()
             return ExtType(typecode, data)
-        raise TypeError("Unknown type object %r" % (obj,))
+        raise TypeError(f"Unknown type object {obj!r}")
 
     def ext_hook(code, data):
         print("ext_hook called", code, data)

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -25,9 +25,7 @@ def testFixRaw():
 
 
 def testFixMap():
-    check(
-        b"\x82\xc2\x81\xc0\xc0\xc3\x81\xc0\x80", {False: {None: None}, True: {None: {}}}
-    )
+    check(b"\x82\xc2\x81\xc0\xc0\xc3\x81\xc0\x80", {False: {None: None}, True: {None: {}}})
 
 
 def testUnsignedInt():

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 from msgpack import unpackb
 

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 
 from msgpack import (

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import pytest
 from array import array

--- a/test/test_newspec.py
+++ b/test/test_newspec.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from msgpack import packb, unpackb, ExtType
 
 

--- a/test/test_obj.py
+++ b/test/test_obj.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 from pytest import raises
 from msgpack import packb, unpackb

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import OrderedDict
 from io import BytesIO
@@ -106,8 +104,8 @@ def testDecodeBinary():
 
 
 def testPackFloat():
-    assert packb(1.0, use_single_float=True) == b"\xca" + struct.pack(str(">f"), 1.0)
-    assert packb(1.0, use_single_float=False) == b"\xcb" + struct.pack(str(">d"), 1.0)
+    assert packb(1.0, use_single_float=True) == b"\xca" + struct.pack(">f", 1.0)
+    assert packb(1.0, use_single_float=False) == b"\xcb" + struct.pack(">d", 1.0)
 
 
 def testArraySize(sizes=[0, 5, 50, 1000]):
@@ -152,7 +150,7 @@ def testMapSize(sizes=[0, 5, 50, 1000]):
     bio.seek(0)
     unpacker = Unpacker(bio, strict_map_key=False)
     for size in sizes:
-        assert unpacker.unpack() == dict((i, i * 2) for i in range(size))
+        assert unpacker.unpack() == {i: i * 2 for i in range(size)}
 
 
 def test_odict():

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -81,9 +81,7 @@ def testPackByteArrays():
 
 
 def testIgnoreUnicodeErrors():
-    re = unpackb(
-        packb(b"abc\xeddef", use_bin_type=False), raw=False, unicode_errors="ignore"
-    )
+    re = unpackb(packb(b"abc\xeddef", use_bin_type=False), raw=False, unicode_errors="ignore")
     assert re == "abcdef"
 
 

--- a/test/test_seq.py
+++ b/test/test_seq.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import io
 import msgpack

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 import io
 from msgpack import Unpacker, BufferFull
 from msgpack import pack, packb

--- a/test/test_stricttype.py
+++ b/test/test_stricttype.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from collections import namedtuple
 from msgpack import packb, unpackb, ExtType
 
@@ -10,7 +8,7 @@ def test_namedtuple():
     def default(o):
         if isinstance(o, T):
             return dict(o._asdict())
-        raise TypeError("Unsupported type %s" % (type(o),))
+        raise TypeError(f"Unsupported type {type(o)}")
 
     packed = packb(T(1, 42), strict_types=True, use_bin_type=True, default=default)
     unpacked = unpackb(packed, raw=False)
@@ -23,7 +21,7 @@ def test_tuple():
     def default(o):
         if isinstance(o, tuple):
             return {"__type__": "tuple", "value": list(o)}
-        raise TypeError("Unsupported type %s" % (type(o),))
+        raise TypeError(f"Unsupported type {type(o)}")
 
     def convert(o):
         if o.get("__type__") == "tuple":
@@ -52,7 +50,7 @@ def test_tuple_ext():
         if code == MSGPACK_EXT_TYPE_TUPLE:
             # Unpack and convert to tuple
             return tuple(unpackb(payload, raw=False, ext_hook=convert))
-        raise ValueError("Unknown Ext code {}".format(code))
+        raise ValueError(f"Unknown Ext code {code}")
 
     data = packb(t, strict_types=True, use_bin_type=True, default=default)
     expected = unpackb(data, raw=False, ext_hook=convert)

--- a/test/test_stricttype.py
+++ b/test/test_stricttype.py
@@ -44,9 +44,7 @@ def test_tuple_ext():
     def default(o):
         if isinstance(o, tuple):
             # Convert to list and pack
-            payload = packb(
-                list(o), strict_types=True, use_bin_type=True, default=default
-            )
+            payload = packb(list(o), strict_types=True, use_bin_type=True, default=default)
             return ExtType(MSGPACK_EXT_TYPE_TUPLE, payload)
         raise TypeError(repr(o))
 

--- a/test/test_subtype.py
+++ b/test/test_subtype.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 from msgpack import packb, unpackb
 from collections import namedtuple

--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -52,7 +52,7 @@ def test_unpacker_hook_refcnt():
 def test_unpacker_ext_hook():
     class MyUnpacker(Unpacker):
         def __init__(self):
-            super(MyUnpacker, self).__init__(ext_hook=self._hook, raw=False)
+            super().__init__(ext_hook=self._hook, raw=False)
 
         def _hook(self, code, data):
             if code == 1:


### PR DESCRIPTION
The following steps have been taken:

1. Black was updated to latest version. The code has been formatted with the new version.
2. The pyupgrade utility is installed. This helped to remove all the code that was needed to support Python < 3.7.

Related issue – #541.