### PR TITLE
add a basic .readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file for Sphinx projects.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Should fix this recently seen build failure:
```
Error

The configuration file required to build documentation is missing from your project.
Add a configuration file to your project to make it build successfully.
Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html
```