### PR TITLE
fix .readthedocs.yaml, fixes #559

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,20 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.11"
+    os: ubuntu-22.04
+    tools:
+        python: "3.11"
+    apt_packages:
+        - build-essential
+    jobs:
+        pre_install:
+            - pip install -r requirements.txt
+            - make cython
+
+python:
+    install:
+        - method: pip
+          path: .
 
 sphinx:
-  configuration: docs/conf.py
+    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,20 +4,20 @@
 version: 2
 
 build:
-    os: ubuntu-22.04
-    tools:
-        python: "3.11"
-    apt_packages:
-        - build-essential
-    jobs:
-        pre_install:
-            - pip install -r requirements.txt
-            - make cython
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  apt_packages:
+    - build-essential
+  jobs:
+    pre_install:
+      - pip install -r requirements.txt
+      - make cython
 
 python:
-    install:
-        - method: pip
-          path: .
+  install:
+    - method: pip
+      path: .
 
 sphinx:
-    configuration: docs/conf.py
+  configuration: docs/conf.py


### PR DESCRIPTION
currently, api docs seem rather empty.

try:

- apt install build-essential (so we have gcc, make, etc.)
- install from requirements.txt
- "make cython"
- "pip install ."