### PR TITLE
Avoid using floaring points during timestamp-datetime conversions

### DIFF
--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -157,7 +157,9 @@ class Timestamp:
         :rtype: `datetime.datetime`
         """
         utc = datetime.timezone.utc
-        return datetime.datetime.fromtimestamp(0, utc) + datetime.timedelta(seconds=self.to_unix())
+        return datetime.datetime.fromtimestamp(0, utc) + datetime.timedelta(
+            seconds=self.seconds, microseconds=round(self.nanoseconds / 1e3)
+        )
 
     @staticmethod
     def from_datetime(dt):
@@ -165,4 +167,4 @@ class Timestamp:
 
         :rtype: Timestamp
         """
-        return Timestamp.from_unix(dt.timestamp())
+        return Timestamp(seconds=int(dt.timestamp() // 1), nanoseconds=dt.microsecond * 10**3)

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -86,6 +86,24 @@ def test_timestamp_datetime():
     utc = datetime.timezone.utc
     assert t.to_datetime() == datetime.datetime(1970, 1, 1, 0, 0, 42, 0, tzinfo=utc)
 
+    ts = datetime.datetime(2024, 4, 16, 8, 43, 9, 420317, tzinfo=utc)
+    ts2 = datetime.datetime(2024, 4, 16, 8, 43, 9, 420318, tzinfo=utc)
+
+    assert Timestamp.from_datetime(ts2).nanoseconds - Timestamp.from_datetime(ts).nanoseconds == 1e3
+
+    ts3 = datetime.datetime(2024, 4, 16, 8, 43, 9, 4256)
+    ts4 = datetime.datetime(2024, 4, 16, 8, 43, 9, 4257)
+    assert (
+        Timestamp.from_datetime(ts4).nanoseconds - Timestamp.from_datetime(ts3).nanoseconds == 1e3
+    )
+
+    assert Timestamp.from_datetime(ts).to_datetime() == ts
+
+    t2 = Timestamp(1713256989, 420318123)
+    t3 = Timestamp(1713256989, 420318499)
+    t4 = Timestamp(1713256989, 420318501)
+    assert t2.to_datetime() == t3.to_datetime() != t4.to_datetime()
+
 
 def test_unpack_datetime():
     t = Timestamp(42, 14)


### PR DESCRIPTION
Right now, when we convert timestamp to datetime or datetime to timestamp, the library uses floating points to do the conversion. This introduces losses during the conversion as the datetime and timestamp datatypes do not support the same precision(nanoseconds).

For instance if we have a timestamp such as: 
`2024-04-16 08:43:09.420317+00:00` 
with the current implementation the nanoseconds in the resulting `Timestamp` object has `420316934` while it should be `420317000` instead.

or in this timestamp:
`2024-04-16 08:43:09.400000+00:00`
it has `400000095` nanoseconds instead of `400000000`.