### PR TITLE
Cleanup code and pyproject

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ all: cython
 
 .PHONY: format
 format:
-	pipx run ruff format $(PYTHON_SOURCES)
+	ruff format $(PYTHON_SOURCES)
 
 .PHONY: lint
 lint:
-	pipx run ruff check $(PYTHON_SOURCES)
+	ruff check $(PYTHON_SOURCES)
 
 .PHONY: doc
 doc:

--- a/msgpack/__init__.py
+++ b/msgpack/__init__.py
@@ -1,20 +1,20 @@
-from .exceptions import *
-from .ext import ExtType, Timestamp
-
+# ruff: noqa: F401
 import os
 
+from .exceptions import *  # noqa: F403
+from .ext import ExtType, Timestamp
 
 version = (1, 0, 8)
 __version__ = "1.0.8"
 
 
 if os.environ.get("MSGPACK_PUREPYTHON"):
-    from .fallback import Packer, unpackb, Unpacker
+    from .fallback import Packer, Unpacker, unpackb
 else:
     try:
-        from ._cmsgpack import Packer, unpackb, Unpacker
+        from ._cmsgpack import Packer, Unpacker, unpackb
     except ImportError:
-        from .fallback import Packer, unpackb, Unpacker
+        from .fallback import Packer, Unpacker, unpackb
 
 
 def pack(o, stream, **kwargs):

--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -1,6 +1,6 @@
-from collections import namedtuple
 import datetime
 import struct
+from collections import namedtuple
 
 
 class ExtType(namedtuple("ExtType", "code data")):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -669,7 +669,7 @@ class Packer:
         self._buffer = BytesIO()
         self._datetime = bool(datetime)
         self._unicode_errors = unicode_errors or "strict"
-        if not callable(default):
+        if default is not None and not callable(default):
             raise TypeError("default must be callable")
         self._default = default
 

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -6,23 +6,18 @@ import struct
 
 
 if hasattr(sys, "pypy_version_info"):
-    # StringIO is slow on PyPy, StringIO is faster.  However: PyPy's own
-    # StringBuilder is fastest.
     from __pypy__ import newlist_hint
+    from __pypy__.builders import BytesBuilder
 
-    try:
-        from __pypy__.builders import BytesBuilder as StringBuilder
-    except ImportError:
-        from __pypy__.builders import StringBuilder
-    USING_STRINGBUILDER = True
+    _USING_STRINGBUILDER = True
 
-    class StringIO:
+    class BytesIO:
         def __init__(self, s=b""):
             if s:
-                self.builder = StringBuilder(len(s))
+                self.builder = BytesBuilder(len(s))
                 self.builder.append(s)
             else:
-                self.builder = StringBuilder()
+                self.builder = BytesBuilder()
 
         def write(self, s):
             if isinstance(s, memoryview):
@@ -35,14 +30,13 @@ if hasattr(sys, "pypy_version_info"):
             return self.builder.build()
 
 else:
-    USING_STRINGBUILDER = False
-    from io import BytesIO as StringIO
+    from io import BytesIO
 
     newlist_hint = lambda size: []
+    _USING_STRINGBUILDER = False
 
 
 from .exceptions import BufferFull, OutOfData, ExtraData, FormatError, StackError
-
 from .ext import ExtType, Timestamp
 
 
@@ -335,6 +329,7 @@ class Unpacker:
 
         # Use extend here: INPLACE_ADD += doesn't reliably typecast memoryview in jython
         self._buffer.extend(view)
+        view.release()
 
     def _consume(self):
         """Gets rid of the used parts of the buffer."""
@@ -671,7 +666,7 @@ class Packer:
         self._use_float = use_single_float
         self._autoreset = autoreset
         self._use_bin_type = use_bin_type
-        self._buffer = StringIO()
+        self._buffer = BytesIO()
         self._datetime = bool(datetime)
         self._unicode_errors = unicode_errors or "strict"
         if default is not None:
@@ -807,18 +802,18 @@ class Packer:
         try:
             self._pack(obj)
         except:
-            self._buffer = StringIO()  # force reset
+            self._buffer = BytesIO()  # force reset
             raise
         if self._autoreset:
             ret = self._buffer.getvalue()
-            self._buffer = StringIO()
+            self._buffer = BytesIO()
             return ret
 
     def pack_map_pairs(self, pairs):
         self._pack_map_pairs(len(pairs), pairs)
         if self._autoreset:
             ret = self._buffer.getvalue()
-            self._buffer = StringIO()
+            self._buffer = BytesIO()
             return ret
 
     def pack_array_header(self, n):
@@ -827,7 +822,7 @@ class Packer:
         self._pack_array_header(n)
         if self._autoreset:
             ret = self._buffer.getvalue()
-            self._buffer = StringIO()
+            self._buffer = BytesIO()
             return ret
 
     def pack_map_header(self, n):
@@ -836,7 +831,7 @@ class Packer:
         self._pack_map_header(n)
         if self._autoreset:
             ret = self._buffer.getvalue()
-            self._buffer = StringIO()
+            self._buffer = BytesIO()
             return ret
 
     def pack_ext_type(self, typecode, data):
@@ -925,11 +920,11 @@ class Packer:
 
         This method is useful only when autoreset=False.
         """
-        self._buffer = StringIO()
+        self._buffer = BytesIO()
 
     def getbuffer(self):
         """Return view of internal buffer."""
-        if USING_STRINGBUILDER:
+        if _USING_STRINGBUILDER:
             return memoryview(self.bytes())
         else:
             return self._buffer.getbuffer()

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -1,9 +1,8 @@
 """Fallback pure Python implementation of msgpack"""
 
-from datetime import datetime as _DateTime
-import sys
 import struct
-
+import sys
+from datetime import datetime as _DateTime
 
 if hasattr(sys, "pypy_version_info"):
     from __pypy__ import newlist_hint
@@ -32,13 +31,14 @@ if hasattr(sys, "pypy_version_info"):
 else:
     from io import BytesIO
 
-    newlist_hint = lambda size: []
     _USING_STRINGBUILDER = False
 
+    def newlist_hint(size):
+        return []
 
-from .exceptions import BufferFull, OutOfData, ExtraData, FormatError, StackError
+
+from .exceptions import BufferFull, ExtraData, FormatError, OutOfData, StackError
 from .ext import ExtType, Timestamp
-
 
 EX_SKIP = 0
 EX_CONSTRUCT = 1
@@ -669,9 +669,8 @@ class Packer:
         self._buffer = BytesIO()
         self._datetime = bool(datetime)
         self._unicode_errors = unicode_errors or "strict"
-        if default is not None:
-            if not callable(default):
-                raise TypeError("default must be callable")
+        if not callable(default):
+            raise TypeError("default must be callable")
         self._default = default
 
     def _pack(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,17 +48,9 @@ version = {attr = "msgpack.__version__"}
 [tool.ruff]
 line-length = 100
 target-version = "py38"
-lint.ignore = []
 lint.select = [
-    # pycodestyle
-    "E",
-    # Pyflakes
-    "F",
-    # isort
-    "I",
-    # pyupgrade
-    #"UP",
+    "E", # pycodestyle
+    "F", # Pyflakes
+    "I", # isort
+    #"UP", pyupgrade
 ]
-
-[tool.ruff.lint.per-file-ignores]
-#"msgpack/__init__.py" = ["F401", "F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,16 @@ version = {attr = "msgpack.__version__"}
 line-length = 100
 target-version = "py38"
 lint.ignore = []
+lint.select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # isort
+    "I",
+    # pyupgrade
+    #"UP",
+]
 
 [tool.ruff.lint.per-file-ignores]
-"msgpack/__init__.py" = ["F401", "F403"]
-"msgpack/fallback.py" = ["E731"]
-"test/test_seq.py" = ["E501"]
+#"msgpack/__init__.py" = ["F401", "F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,6 @@ include-package-data = false
 [tool.setuptools.dynamic]
 version = {attr = "msgpack.__version__"}
 
-[tool.black]
-line-length = 100
-target-version = ["py37"]
-skip_string_normalization = true
-
 [tool.ruff]
 line-length = 100
 target-version = "py38"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import os
 import sys
-from setuptools import setup, Extension
+
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
-
 
 PYPY = hasattr(sys, "pypy_version_info")
 

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from msgpack import packb, unpackb, Packer
+from msgpack import Packer, packb, unpackb
 
 
 def test_unpack_buffer():

--- a/test/test_except.py
+++ b/test/test_except.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-from pytest import raises
-from msgpack import packb, unpackb, Unpacker, FormatError, StackError, OutOfData
-
 import datetime
+
+from pytest import raises
+
+from msgpack import FormatError, OutOfData, StackError, Unpacker, packb, unpackb
 
 
 class DummyException(Exception):

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -1,4 +1,5 @@
 import array
+
 import msgpack
 from msgpack import ExtType
 

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -2,14 +2,14 @@
 import pytest
 
 from msgpack import (
-    packb,
-    unpackb,
-    Packer,
-    Unpacker,
     ExtType,
+    Packer,
     PackOverflowError,
     PackValueError,
+    Unpacker,
     UnpackValueError,
+    packb,
+    unpackb,
 )
 
 

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from array import array
+
 from msgpack import packb, unpackb
 
 

--- a/test/test_newspec.py
+++ b/test/test_newspec.py
@@ -1,4 +1,4 @@
-from msgpack import packb, unpackb, ExtType
+from msgpack import ExtType, packb, unpackb
 
 
 def test_str8():

--- a/test/test_obj.py
+++ b/test/test_obj.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from pytest import raises
+
 from msgpack import packb, unpackb
 
 

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
+import struct
 from collections import OrderedDict
 from io import BytesIO
-import struct
 
 import pytest
 
-from msgpack import packb, unpackb, Unpacker, Packer
+from msgpack import Packer, Unpacker, packb, unpackb
 
 
 def check(data, use_list=False):

--- a/test/test_read_size.py
+++ b/test/test_read_size.py
@@ -1,6 +1,6 @@
 """Test Unpacker's read_array_header and read_map_header methods"""
 
-from msgpack import packb, Unpacker, OutOfData
+from msgpack import OutOfData, Unpacker, packb
 
 UnexpectedTypeException = ValueError
 

--- a/test/test_seq.py
+++ b/test/test_seq.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
-
+# ruff: noqa: E501
+# ignore line length limit for long comments
 import io
-import msgpack
 
+import msgpack
 
 binarydata = bytes(bytearray(range(256)))
 

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import io
-from msgpack import Unpacker, BufferFull
-from msgpack import pack, packb
-from msgpack.exceptions import OutOfData
+
 from pytest import raises
+
+from msgpack import BufferFull, Unpacker, pack, packb
+from msgpack.exceptions import OutOfData
 
 
 def test_partialdata():

--- a/test/test_stricttype.py
+++ b/test/test_stricttype.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
-from msgpack import packb, unpackb, ExtType
+
+from msgpack import ExtType, packb, unpackb
 
 
 def test_namedtuple():

--- a/test/test_subtype.py
+++ b/test/test_subtype.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from msgpack import packb
 from collections import namedtuple
+
+from msgpack import packb
 
 
 class MyList(list):

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -1,5 +1,7 @@
-import pytest
 import datetime
+
+import pytest
+
 import msgpack
 from msgpack.ext import Timestamp
 

--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -1,12 +1,9 @@
-from io import BytesIO
 import sys
-from msgpack import Unpacker, packb, OutOfData, ExtType
-from pytest import raises, mark
+from io import BytesIO
 
-try:
-    from itertools import izip as zip
-except ImportError:
-    pass
+from pytest import mark, raises
+
+from msgpack import ExtType, OutOfData, Unpacker, packb
 
 
 def test_unpack_array_header_from_file():


### PR DESCRIPTION
* use isort
* fallback: use BytesIO instead of StringIO. We had dropped Python 2 already.