### PR TITLE
do not install cython as build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [build-system]
-requires = [
-    # Also declared in requirements.txt, if updating here please also update there
-    "Cython~=3.0.10",
-    "setuptools >= 69.5.1",
-]
+requires = ["setuptools >= 69.5.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -8,47 +8,6 @@ from setuptools.command.sdist import sdist
 
 PYPY = hasattr(sys, "pypy_version_info")
 
-
-class NoCython(Exception):
-    pass
-
-
-try:
-    import Cython.Compiler.Main as cython_compiler
-
-    have_cython = True
-except ImportError:
-    have_cython = False
-
-
-def cythonize(src):
-    if not have_cython:
-        raise Exception("Cython is required for building from checkout")
-    sys.stderr.write(f"cythonize: {src!r}\n")
-    cython_compiler.compile([src])
-
-
-def ensure_source(src):
-    pyx = os.path.splitext(src)[0] + ".pyx"
-
-    if not os.path.exists(src) or have_cython and os.stat(src).st_mtime < os.stat(pyx).st_mtime:
-        cythonize(pyx)
-
-
-class BuildExt(build_ext):
-    def build_extension(self, ext):
-        for src in ext.sources:
-            ensure_source(src)
-        return build_ext.build_extension(self, ext)
-
-
-# Cython is required for sdist
-class Sdist(sdist):
-    def __init__(self, *args, **kwargs):
-        cythonize("msgpack/_cmsgpack.pyx")
-        sdist.__init__(self, *args, **kwargs)
-
-
 libraries = []
 macros = []
 ext_modules = []
@@ -69,9 +28,7 @@ if not PYPY and not os.environ.get("MSGPACK_PUREPYTHON"):
     )
 del libraries, macros
 
-
 setup(
-    cmdclass={"build_ext": BuildExt, "sdist": Sdist},
     ext_modules=ext_modules,
     packages=["msgpack"],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 from setuptools import Extension, setup
-from setuptools.command.build_ext import build_ext
-from setuptools.command.sdist import sdist
 
 PYPY = hasattr(sys, "pypy_version_info")
 


### PR DESCRIPTION
User can not cythonize during `pip install msgpack`.
So remove cython from build dependency.

If user need to use another Cython, user should download sdist, unzip, manually cythonize, and `pip install .`.