### PR TITLE
Add monthly downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/msgpack/msgpack-python/actions/workflows/wheel.yml/badge.svg)](https://github.com/msgpack/msgpack-python/actions/workflows/wheel.yml)
 [![Documentation Status](https://readthedocs.org/projects/msgpack-python/badge/?version=latest)](https://msgpack-python.readthedocs.io/en/latest/?badge=latest)
+[![msgpack Downloads Last Month](https://assets.piptrends.com/get-last-month-downloads-badge/msgpack.svg 'msgpack Downloads Last Month by pip Trends')](https://piptrends.com/package/msgpack)
 
 ## What's this
 


### PR DESCRIPTION
This PR is to add a monthly downloads count badge to the README.  
There are more badges and widgets, you can view them here - https://piptrends.com/widgets/msgpack
(If necessary, the link from the badge to the package's pip Trends page can be removed. We just want to showcase a badge we have created.)