### PR TITLE
add logic to convert dict list key to tuple

### DIFF
--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -199,6 +199,25 @@ static inline int unpack_callback_map_item(unpack_user* u, unsigned int current,
     if (PyUnicode_CheckExact(k)) {
         PyUnicode_InternInPlace(&k);
     }
+    if (PyList_CheckExact(k)) {
+        Py_ssize_t list_size = PyList_Size(k);
+        PyObject* tuple = PyTuple_New(list_size);
+
+        if (tuple == NULL) {
+            return -1;
+        }
+
+        for (Py_ssize_t i = 0; i < list_size; i++) {
+            PyObject* item = PyList_GetItem(k, i);
+            Py_INCREF(item);
+            if (PyTuple_SetItem(tuple, i, item) != 0) {
+                Py_DECREF(tuple);
+                return -1;
+            }
+        }
+        Py_DECREF(k);
+        k = tuple;
+    }
     if (u->has_pairs_hook) {
         msgpack_unpack_object item = PyTuple_Pack(2, k, v);
         if (!item)

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -134,3 +134,6 @@ def test_match():
 
 def test_unicode():
     assert unpackb(packb("foobar"), use_list=1) == "foobar"
+
+def test_dict_tuple_key():
+    unpackb(packb({(1, 2): 3}), strict_map_key=False)


### PR DESCRIPTION
Python dictionaries with tuples as a key can be packed, however when they are unpacked an error occurs because the key
comes back as a list rather than a tuple, although it's possible to set at the top-level use_list=False this is undesirable as 
it affects everything. This solution is slightly wasteful as it results in a list being created and then converted to a tuple however it has the advantage of being the smallest change to the code that makes this work.
