### PR TITLE
ci: add support for building windows on arm wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "windows-11-arm", "macos-latest"]
         py: ["3.14-dev", "3.13", "3.12", "3.11", "3.10", "3.9"]
         exclude:
-          - os: window-11-arm
+          - os: windows-11-arm
             py: "3.9"
-          - os: window-11-arm
+          - os: windows-11-arm
             py: "3.10"
     runs-on: ${{ matrix.os }}
     name: Run test with Python ${{ matrix.py }} on ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,11 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         py: ["3.14-dev", "3.13", "3.12", "3.11", "3.10", "3.9"]
-
+        exclude:
+          - os: window-11-arm
+            py: "3.9"
+          - os: window-11-arm
+            py: "3.10"
     runs-on: ${{ matrix.os }}
     name: Run test with Python ${{ matrix.py }} on ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Prepare
         shell: bash
         run: |
-          pip install -U pip
-          pip install -r requirements.txt pytest
+          python -m pip install -U pip
+          python -m pip install -r requirements.txt pytest
 
       - name: Build
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "windows-11-arm", "macos-latest"]
         py: ["3.14-dev", "3.13", "3.12", "3.11", "3.10", "3.9"]
         exclude:
           - os: window-11-arm

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is for intel
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "macos-13", "macos-latest"]
+        os: ["ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "windows-11-arm", "macos-13", "macos-latest"]
     runs-on: ${{ matrix.os }}
     name: Build wheels on ${{ matrix.os }}
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {package}/test"
-          CIBW_SKIP: "pp* cp38-*"
+          CIBW_SKIP: "pp* cp38-* cp39-win_arm64 cp310-win_arm64"
 
       - name: Build sdist
         if: runner.os == 'Linux' && runner.arch == 'X64'


### PR DESCRIPTION
PR Description:

* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
* GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
* Currently, official msgpack-python Python wheels are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular msgpack-python library natively.
* This PR introduces support for building msgpack-python wheels on Windows ARM64, improving accessibility for developers and end users on this emerging platform.