### PR TITLE
Drop Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,20 +6,17 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "msgpack"
 dynamic = ["version"]
-# `license = "Apache-2.0"` is preferred. But keep old syntax for Python 3.8 compatibility.
-# https://github.com/msgpack/msgpack-python/pull/637
-license = {text="Apache 2.0"}
+license = "Apache-2.0"
 authors = [{name="Inada Naoki", email="songofacandy@gmail.com"}]
 description = "MessagePack serializer"
 readme = "README.md"
 keywords = ["msgpack", "messagepack", "serializer", "serialization", "binary"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",
     "Topic :: File Formats",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -46,7 +43,7 @@ version = {attr = "msgpack.__version__"}
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 lint.select = [
     "E", # pycodestyle
     "F", # Pyflakes


### PR DESCRIPTION
Python 3.8 is dead, and the faulty license gives a warning in Python 3.14:

      /Users/neil/.cache/uv/builds-v0/.tmpssvJcI/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML
      table is deprecated

              Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************