### PR TITLE
Fix Timestamp.from_datetime returning wrong value for pre-epoch datetimes

### DIFF
--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -167,4 +167,4 @@ class Timestamp:
 
         :rtype: Timestamp
         """
-        return Timestamp(seconds=int(dt.timestamp()), nanoseconds=dt.microsecond * 1000)
+        return Timestamp(seconds=int(dt.timestamp() // 1), nanoseconds=dt.microsecond * 1000)

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -103,6 +103,13 @@ def test_timestamp_datetime():
 
     assert Timestamp.from_datetime(ts).to_datetime() == ts
 
+    # Regression test: pre-epoch fractional seconds must floor toward -inf.
+    pre_epoch = datetime.datetime(1969, 12, 31, 23, 59, 59, 500000, tzinfo=utc)
+    ts_pre_epoch = Timestamp.from_datetime(pre_epoch)
+    assert ts_pre_epoch.seconds == -1
+    assert ts_pre_epoch.nanoseconds == 500000000
+    assert ts_pre_epoch.to_datetime() == pre_epoch
+
 
 def test_unpack_datetime():
     t = Timestamp(42, 14)


### PR DESCRIPTION
`Timestamp.from_datetime()` uses `int(dt.timestamp())` to compute the seconds component, but `int()` truncates towards zero. For pre-epoch datetimes with non-zero microseconds, this produces the wrong value:

```python
import datetime
dt = datetime.datetime(1969, 12, 31, 23, 59, 59, 500000, tzinfo=datetime.timezone.utc)
# dt.timestamp() == -0.5
# int(-0.5) == 0  (truncation towards zero)
# Expected: Timestamp(seconds=-1, nanoseconds=500000000)
# Actual:   Timestamp(seconds=0, nanoseconds=500000000)  <-- +0.5s instead of -0.5s!
```

The sign of the time gets flipped. `from_unix()` already handles this correctly using floor division (`int(unix_sec // 1)`). This change makes `from_datetime()` consistent.
