### PR TITLE
Add missing autoreset in Packer.pack_ext_type

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -291,6 +291,10 @@ cdef class Packer:
             raise ValueError("ext data too large")
         msgpack_pack_ext(&self.pk, typecode, len(data))
         msgpack_pack_raw_body(&self.pk, data, len(data))
+        if self.autoreset:
+            buf = PyBytes_FromStringAndSize(self.pk.buf, self.pk.length)
+            self.pk.length = 0
+            return buf
 
     @cython.critical_section
     def pack_array_header(self, long long size):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -861,6 +861,10 @@ class Packer:
             self._buffer.write(b"\xc9" + struct.pack(">I", L))
         self._buffer.write(struct.pack("B", typecode))
         self._buffer.write(data)
+        if self._autoreset:
+            ret = self._buffer.getvalue()
+            self._buffer = BytesIO()
+            return ret
 
     def _pack_array_header(self, n):
         if n <= 0x0F:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+dependencies = []
 
 [project.urls]
 Homepage = "https://msgpack.org/"
@@ -42,4 +43,10 @@ lint.select = [
     "F", # Pyflakes
     "I", # isort
     #"UP", pyupgrade
+]
+
+[dependency-groups]
+dev = [
+    "cython>=3.2.5",
+    "pytest>=9.0.3",
 ]

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -6,7 +6,7 @@ from msgpack import ExtType
 
 def test_pack_ext_type():
     def p(s):
-        packer = msgpack.Packer()
+        packer = msgpack.Packer(autoreset=False)
         packer.pack_ext_type(0x42, s)
         return packer.bytes()
 
@@ -18,6 +18,15 @@ def test_pack_ext_type():
     assert p(b"ABC") == b"\xc7\x03\x42ABC"  # ext 8
     assert p(b"A" * 0x0123) == b"\xc8\x01\x23\x42" + b"A" * 0x0123  # ext 16
     assert p(b"A" * 0x00012345) == b"\xc9\x00\x01\x23\x45\x42" + b"A" * 0x00012345  # ext 32
+
+
+def test_pack_ext_type_autoreset():
+    packer = msgpack.Packer()
+
+    assert packer.pack_ext_type(0x42, b"A") == b"\xd4\x42A"
+    assert packer.bytes() == b""
+    assert packer.pack_ext_type(0x42, b"ABC") == b"\xc7\x03\x42ABC"
+    assert packer.bytes() == b""
 
 
 def test_unpack_ext_type():


### PR DESCRIPTION
`Packer.pack_ext_type()` writes to the internal buffer but never checks `self._autoreset`. Every other public pack method (`pack`, `pack_map_pairs`, `pack_array_header`, `pack_map_header`) has this pattern:

```python
if self._autoreset:
    ret = self._buffer.getvalue()
    self._buffer = BytesIO()
    return ret
```

Without it, `pack_ext_type()` always returns `None`, and the packed ext data stays in the buffer. The next call to `pack()` then returns both the extension data and the new value concatenated together, corrupting the serialized stream.

```python
packer = msgpack.Packer()
result = packer.pack_ext_type(5, b'\x01\x02\x03')
# result is None, expected bytes

packer.pack(99)
# Returns 7 bytes (ext header + ext data + int) instead of 1 byte
```
