### PR TITLE
ci: add riscv64 manylinux/musllinux wheels

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -12,9 +12,19 @@ jobs:
     strategy:
       matrix:
         # macos-13 is for intel
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "windows-11-arm", "macos-13", "macos-latest"]
+        include:
+        - os: ubuntu-24.04
+        - os: ubuntu-24.04-arm
+        - os: windows-latest
+        - os: windows-11-arm
+        - os: macos-13
+        - os: macos-latest
+        - os: ubuntu-24.04
+          cibw_archs: riscv64
+          name_suffix: "-riscv64"
+
     runs-on: ${{ matrix.os }}
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}${{ matrix.name_suffix || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -28,12 +38,19 @@ jobs:
           pip install -r requirements.txt
           make cython
 
+      - name: Set up QEMU for emulation
+        if: matrix.cibw_archs == 'riscv64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.cibw_archs }}
+
       - name: Build
         uses: pypa/cibuildwheel@v3.3.0
         env:
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {package}/test"
           CIBW_SKIP: "pp* cp38-* cp39-* cp310-win_arm64"
+          CIBW_ARCHS: ${{ matrix.cibw_archs || 'auto' }}
 
       - name: Build sdist
         if: runner.os == 'Linux' && runner.arch == 'X64'
@@ -44,7 +61,7 @@ jobs:
       - name: Upload Wheels to artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}${{ matrix.name_suffix || '' }}
           path: wheelhouse
 
   # combine all wheels into one artifact


### PR DESCRIPTION
Now that cibuildwheel and PyPI support riscv64, we can start building riscv64 wheels.

Because there is no native riscv64 runner available, this PR adds a QEMU-based riscv64 job to the cibuildwheel workflow.