### PR TITLE
fix: check return code in `unpack_callback_int64`

### DIFF
--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -103,7 +103,7 @@ static inline int unpack_callback_int64(unpack_user* u, int64_t d, msgpack_unpac
         p = PyLong_FromLongLong((PY_LONG_LONG)d);
     } else {
         p = PyLong_FromLong((long)d);
-    }
+    PyObject *p = PyLong_FromLongLong((PY_LONG_LONG)d);
     if (!p)
         return -1;
     *o = p;

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -70,12 +70,7 @@ static inline int unpack_callback_uint32(unpack_user* u, uint32_t d, msgpack_unp
 
 static inline int unpack_callback_uint64(unpack_user* u, uint64_t d, msgpack_unpack_object* o)
 {
-    PyObject *p;
-    if (d > LONG_MAX) {
-        p = PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG)d);
-    } else {
-        p = PyLong_FromLong((long)d);
-    }
+    PyObject *p = PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG)d);
     if (!p)
         return -1;
     *o = p;

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -98,11 +98,6 @@ static inline int unpack_callback_int8(unpack_user* u, int8_t d, msgpack_unpack_
 
 static inline int unpack_callback_int64(unpack_user* u, int64_t d, msgpack_unpack_object* o)
 {
-    PyObject *p;
-    if (d > LONG_MAX || d < LONG_MIN) {
-        p = PyLong_FromLongLong((PY_LONG_LONG)d);
-    } else {
-        p = PyLong_FromLong((long)d);
     PyObject *p = PyLong_FromLongLong((PY_LONG_LONG)d);
     if (!p)
         return -1;

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -109,6 +109,8 @@ static inline int unpack_callback_int64(unpack_user* u, int64_t d, msgpack_unpac
     } else {
         p = PyLong_FromLong((long)d);
     }
+    if (!p)
+        return -1;
     *o = p;
     return 0;
 }


### PR DESCRIPTION
This simply adds a null pointer check after calling `PyLong_FromLongLong` / `PyLong_FromLong` like other similar functions do it ([example here](https://github.com/msgpack/msgpack-python/blob/5142b3d1b1929104103a14c1d7e148b8b8bb7896/msgpack/unpack.h#L71-L83)).