### PR TITLE
fix: check `unpack_callback_uint32` result

### DIFF
--- a/msgpack/unpack_container_header.h
+++ b/msgpack/unpack_container_header.h
@@ -45,7 +45,10 @@ static inline int unpack_container_header(unpack_context* ctx, const char* data,
         PyErr_SetString(PyExc_ValueError, "Unexpected type header on stream");
         return -1;
     }
-    unpack_callback_uint32(&ctx->user, size, &ctx->stack[0].obj);
+
+    if (unpack_callback_uint32(&ctx->user, size, &ctx->stack[0].obj) < 0)
+        return -1;
+
     return 1;
 }
 


### PR DESCRIPTION
## What does this PR do?

Similar to #665, just a return value check to propagate the error in case one happens (instead of silently ignoring it). 

Note that as opposed to the previous lines, we don't need to `PyErr_SetString` since `unpack_callback_uint32` calls `PyLong_FromSize_t` which itself should set whatever Python error is relevant; we just need to make it clear to the caller that an error occurred. 

**Note** looking at the usages of the function ([here for example](https://github.com/msgpack/msgpack-python/blob/6357bc272c83fb450fbe7de7e7ca15d815e75174/msgpack/_unpacker.pyx#L516-L523), which calls into [this](https://github.com/msgpack/msgpack-python/blob/6357bc272c83fb450fbe7de7e7ca15d815e75174/msgpack/_unpacker.pyx#L455-L485)) it seems like it checks for error values -2 and -3, but -1 will just `raise ValueError("Unpack failed: error = %d" % (ret,))` -- I don't know if that's expected? Shouldn't it juse `raise` to raise the existing exception set by `PyErr_SetString` or whichever? Seems like something that should probably handled in a different PR/issue, but figured I'd raise it.