### PR TITLE
fix: re-raise existing exception when available

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -205,7 +205,10 @@ def unpackb(object packed, *, object object_hook=None, object list_hook=None,
         raise FormatError
     elif ret == -3:
         raise StackError
-    raise ValueError("Unpack failed: error = %d" % (ret,))
+    elif PyErr_Occurred():
+        raise
+    else:
+        raise ValueError("Unpack failed: error = %d" % (ret,))
 
 
 cdef class Unpacker:
@@ -481,6 +484,8 @@ cdef class Unpacker:
                 raise FormatError
             elif ret == -3:
                 raise StackError
+            elif PyErr_Occurred():
+                raise
             else:
                 raise ValueError("Unpack failed: error = %d" % (ret,))
 

--- a/test/test_except.py
+++ b/test/test_except.py
@@ -4,7 +4,7 @@ import datetime
 
 from pytest import raises
 
-from msgpack import FormatError, OutOfData, StackError, Unpacker, packb, unpackb
+from msgpack import ExtType, FormatError, OutOfData, StackError, Unpacker, packb, unpackb
 
 
 class DummyException(Exception):
@@ -30,6 +30,34 @@ def test_raise_from_object_hook():
         packb({"fizz": {"buzz": "spam"}}),
         object_pairs_hook=hook,
     )
+
+
+def test_raise_from_list_hook():
+    def hook(lst: list) -> list:
+        raise DummyException
+
+    with raises(DummyException):
+        unpackb(packb([1, 2, 3]), list_hook=hook)
+
+    with raises(DummyException):
+        unpacker = Unpacker(list_hook=hook)
+        unpacker.feed(packb([1, 2, 3]))
+        unpacker.unpack()
+
+
+def test_raise_from_ext_hook():
+    def hook(code: int, data: bytes) -> ExtType:
+        raise DummyException
+
+    packed = packb(ExtType(42, b"hello"))
+
+    with raises(DummyException):
+        unpackb(packed, ext_hook=hook)
+
+    with raises(DummyException):
+        unpacker = Unpacker(ext_hook=hook)
+        unpacker.feed(packed)
+        unpacker.unpack()
 
 
 def test_invalidvalue():


### PR DESCRIPTION
## What is this PR?

This PR addresses an issue I found while working on #666 and reported in the description there. 

Looking at the usages of `unpack_callback_uint32` ([here for example](https://github.com/msgpack/msgpack-python/blob/6357bc272c83fb450fbe7de7e7ca15d815e75174/msgpack/_unpacker.pyx#L516-L523), which calls into [this](https://github.com/msgpack/msgpack-python/blob/6357bc272c83fb450fbe7de7e7ca15d815e75174/msgpack/_unpacker.pyx#L455-L485)) it seems like it checks for error values -2 and -3, but -1 will just `raise ValueError("Unpack failed: error = %d" % (ret,))`.

It believe it should just `raise` to raise the existing exception set by `PyErr_SetString` if it exists. This PR addresses that problem here and another place. 