### PR TITLE
fix: avoid memory leak when decoding invalid nested arrays

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -322,6 +322,7 @@ cdef class Unpacker:
         self.buf = NULL
 
     def __dealloc__(self):
+        unpack_clear(&self.ctx)
         PyMem_Free(self.buf)
         self.buf = NULL
 

--- a/msgpack/unpack_template.h
+++ b/msgpack/unpack_template.h
@@ -72,6 +72,14 @@ static inline PyObject* unpack_data(unpack_context* ctx)
 
 static inline void unpack_clear(unpack_context *ctx)
 {
+    unsigned int i;
+    for (i = 1; i < ctx->top; i++) {
+        Py_CLEAR(ctx->stack[i].obj);
+        /* map_key holds a live reference only while waiting for the value */
+        if (ctx->stack[i].ct == CT_MAP_VALUE) {
+            Py_CLEAR(ctx->stack[i].map_key);
+        }
+    }
     Py_CLEAR(ctx->stack[0].obj);
 }
 

--- a/test/test_except.py
+++ b/test/test_except.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import datetime
+import gc
+import tracemalloc
 
 from pytest import raises
 
@@ -78,6 +80,39 @@ def test_invalidvalue():
 
     with raises(StackError):
         unpackb(b"\x91" * 3000)  # nested fixarray(len=1)
+
+
+def test_no_memory_leak_on_nested_invalid_tag() -> None:
+    """Regression test: unpacking nested arrays containing an invalid tag must not leak objects."""
+
+    kwargs: dict = {
+        "raw": False,
+        "strict_map_key": False,
+        "max_array_len": 1 << 20,
+        "max_map_len": 1 << 20,
+    }
+    n = 1000
+
+    for depth in range(1, 15):
+        data = bytes([0x91] * depth + [0xC1])
+
+        gc.collect()
+        tracemalloc.start()
+        s1 = tracemalloc.take_snapshot()
+
+        for _ in range(n):
+            try:
+                unpackb(data, **kwargs)
+            except Exception:
+                pass
+
+        gc.collect()
+        s2 = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        leaked = sum(s.count_diff for s in s2.compare_to(s1, "lineno") if s.count_diff > 0)
+        per_call = leaked / n
+        assert per_call < 1.0, f"depth={depth}: {per_call:.2f} leaked objects/call (expected < 1)"
 
 
 def test_strict_map_key():


### PR DESCRIPTION
## What is this PR?

This PR fixes a memory leak that was detected (accidentally) through fuzzing.  
The leak happens in some cases when trying to decode invalid data. When decoding an array, the unpacker uses a stack and pushes a new list to that stack for every nested array element. If it eventually reaches a point where the element to decode is problematic, it returns `-2` which results in `FormatError` being raised, but `unpack_clear` lacks some memory freeing logic (only relevant in the problematic case -- the outermost list is freed but not the other ones) and the objects are lost forever. 

The leak can directly be observed by running the following reproducer, which pushes several nested lists, and eventually one undefined format byte. It results in returning an error, without freeing the intermediate list objects. The logic is run under `tracemalloc`, with explicit GC calls to avoid transient still-alive objects that would be freed at some point. The deeper the nesting, the more objects are leaked. 

```py
import gc
import tracemalloc
import msgpack._cmsgpack as _c

KWARGS = {"raw": False, "strict_map_key": False, "max_array_len": 1 << 20, "max_map_len": 1 << 20}
N = 10000

for depth in range(1, 15):
    data = bytes([0x91] * depth + [0xC1])

    gc.collect()
    tracemalloc.start()
    s1 = tracemalloc.take_snapshot()

    for _ in range(N):
        try:
            _c.unpackb(data, **KWARGS)
        except:
            pass

    gc.collect()
    s2 = tracemalloc.take_snapshot()
    tracemalloc.stop()

    objs = sum(s.count_diff for s in s2.compare_to(s1, "lineno") if s.count_diff > 0)
    print(f"depth={depth}: {objs / N:.1f} leaked obj/call")
```