### PR TITLE
fix: use-after-free in `get_data_from_buffer`

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -130,9 +130,7 @@ cdef inline int get_data_from_buffer(object obj,
         # create a contiguous copy and get buffer
         contiguous = PyMemoryView_GetContiguous(obj, PyBUF_READ, b'C')
         PyObject_GetBuffer(contiguous, view, PyBUF_SIMPLE)
-        # view must hold the only reference to contiguous,
-        # so memory is freed when view is released
-        Py_DECREF(contiguous)
+
     buffer_len[0] = view.len
     buf[0] = <char*> view.buf
     return 1

--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -129,7 +129,8 @@ cdef inline int get_data_from_buffer(object obj,
         PyBuffer_Release(view)
         # create a contiguous copy and get buffer
         contiguous = PyMemoryView_GetContiguous(obj, PyBUF_READ, b'C')
-        PyObject_GetBuffer(contiguous, view, PyBUF_SIMPLE)
+        if PyObject_GetBuffer(contiguous, view, PyBUF_SIMPLE) == -1:
+            raise
 
     buffer_len[0] = view.len
     buf[0] = <char*> view.buf

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -328,8 +328,7 @@ class Unpacker:
             self._buf_checkpoint = 0
 
         # Use extend here: INPLACE_ADD += doesn't reliably typecast memoryview in jython
-        # tobytes ensures compatibility with non-contiguous memoryviews
-        self._buffer.extend(view.tobytes())
+        self._buffer.extend(view if view.contiguous else view.tobytes())
         view.release()
 
     def _consume(self):

--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -328,7 +328,8 @@ class Unpacker:
             self._buf_checkpoint = 0
 
         # Use extend here: INPLACE_ADD += doesn't reliably typecast memoryview in jython
-        self._buffer.extend(view)
+        # tobytes ensures compatibility with non-contiguous memoryviews
+        self._buffer.extend(view.tobytes())
         view.release()
 
     def _consume(self):

--- a/test/test_memoryview.py
+++ b/test/test_memoryview.py
@@ -97,3 +97,15 @@ def test_multidim_memoryview():
     data = view.cast(view.format, (3, 2))
     packed = packb(data)
     assert packed == b"\xc4\x06\x00\x00\x00\x00\x00\x00"
+
+
+def test_unpack_noncontiguous_memoryview():
+    # Use a multi-byte value so the padded stride-2 view is non-contiguous.
+    packed = packb(2**32)
+    padded = bytearray()
+    for byte in packed:
+        padded.append(byte)
+        padded.append(0)
+    noncont = memoryview(bytes(padded))[::2]
+    assert not noncont.c_contiguous
+    assert unpackb(noncont) == 2**32


### PR DESCRIPTION
## What is this PR?

There currently is a crash happening when unpacking data from a non-contiguous input.

The current PR adds a test to confirm the problem is not happening anymore as well as the fix itself.
Running the reproducer with the fix applied makes the crash go away.

This is a reproducer:

```py
packed = packb(2**32)
padded = bytearray()
for byte in packed:
    padded.append(byte)
    padded.append(0)

noncont = memoryview(bytes(padded))[::2]
assert not noncont.c_contiguous
assert unpackb(noncont) == 2**32
```

Running it results in the following:

```
ASAN_OPTIONS=detect_leaks=0 python -m pytest test/test_memoryview.py -k test_unpack_noncontiguous_memoryview
================================================================= test session starts =================================================================
platform darwin -- Python 3.16.0a0, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/thomas.kowalski/Documents/msgpack-python
configfile: pyproject.toml
collected 14 items / 13 deselected / 1 selected                                                                                                       

test/test_memoryview.py Fatal Python error: Aborted

Current thread 0x00000001ee7898c0 (most recent call first):
  File "/Users/thomas.kowalski/Documents/msgpack-python/test/test_memoryview.py", line 116 in test_unpack_noncontiguous_memoryview
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/python.py", line 166 in pytest_pyfunc_call
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/python.py", line 1720 in runtest
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/runner.py", line 179 in pytest_runtest_call
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/runner.py", line 245 in <lambda>
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/runner.py", line 353 in from_call
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/runner.py", line 244 in call_and_report
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/runner.py", line 137 in runtestprotocol
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/runner.py", line 118 in pytest_runtest_protocol
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/main.py", line 396 in pytest_runtestloop
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/main.py", line 372 in _main
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/main.py", line 318 in wrap_session
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/main.py", line 365 in pytest_cmdline_main
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/config/__init__.py", line 199 in main
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/_pytest/config/__init__.py", line 223 in console_main
  File "/Users/thomas.kowalski/Documents/msgpack-python/venv-asan/lib/python3.16/site-packages/pytest/__main__.py", line 9 in <module>
  File "<frozen runpy>", line 87 in _run_code
  File "<frozen runpy>", line 201 in _run_module_as_main

Current thread's C stack trace (most recent call first):
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _Py_DumpStack+0xf4 [0x102fc4bc0]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at faulthandler_fatal_error+0x470 [0x10300492c]
  Binary file "/usr/lib/system/libsystem_platform.dylib", at _sigtramp+0x38 [0x1829897a4]
  Binary file "/usr/lib/system/libsystem_pthread.dylib", at pthread_kill+0x128 [0x18297f8d8]
  Binary file "/usr/lib/system/libsystem_c.dylib", at abort+0x94 [0x182886790]
  Binary file "/opt/homebrew/Cellar/llvm/22.1.5/lib/clang/22/lib/darwin/libclang_rt.asan_osx_dynamic.dylib", at _ZN11__sanitizer6AtexitEPFvvE+0x0 [0x103efc4cc]
  Binary file "/opt/homebrew/Cellar/llvm/22.1.5/lib/clang/22/lib/darwin/libclang_rt.asan_osx_dynamic.dylib", at _ZN11__sanitizer3DieEv+0x68 [0x103efb9fc]
  Binary file "/opt/homebrew/Cellar/llvm/22.1.5/lib/clang/22/lib/darwin/libclang_rt.asan_osx_dynamic.dylib", at _ZN6__asan19ScopedInErrorReportD2Ev+0x4a8 [0x103eddebc]
  Binary file "/opt/homebrew/Cellar/llvm/22.1.5/lib/clang/22/lib/darwin/libclang_rt.asan_osx_dynamic.dylib", at _ZN6__asan18ReportGenericErrorEmmmmbmjb+0x78c [0x103edd130]
  Binary file "/opt/homebrew/Cellar/llvm/22.1.5/lib/clang/22/lib/darwin/libclang_rt.asan_osx_dynamic.dylib", at __asan_report_load1+0x3c [0x103ede3cc]
  Binary file "/Users/thomas.kowalski/Documents/msgpack-python/msgpack/_cmsgpack.cpython-316-darwin.so", at unpack_execute+0x3b0 [0x10ec58328]
  Binary file "/Users/thomas.kowalski/Documents/msgpack-python/msgpack/_cmsgpack.cpython-316-darwin.so", at unpack_construct+0x38 [0x10ec57f6c]
  Binary file "/Users/thomas.kowalski/Documents/msgpack-python/msgpack/_cmsgpack.cpython-316-darwin.so", at __pyx_pf_7msgpack_9_cmsgpack_2unpackb+0x7c0 [0x10ec70a48]
  Binary file "/Users/thomas.kowalski/Documents/msgpack-python/msgpack/_cmsgpack.cpython-316-darwin.so", at __pyx_pw_7msgpack_9_cmsgpack_3unpackb+0xd7c [0x10ec7010c]
  Binary file "/Users/thomas.kowalski/Documents/msgpack-python/msgpack/_cmsgpack.cpython-316-darwin.so", at __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS+0x198 [0x10ec6e430]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at PyObject_Vectorcall+0xdc [0x102ada240]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _Py_VectorCallInstrumentation_StackRefSteal+0x2b8 [0x102e30e10]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyEval_EvalFrameDefault+0x1d998 [0x102e50dc4]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyEval_Vector+0x420 [0x102e30068]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyObject_VectorcallDictTstate+0x1a4 [0x102ad88a0]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyObject_Call_Prepend+0x134 [0x102adb134]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at slot_tp_call+0x124 [0x102c5d2f0]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyObject_MakeTpCall+0x1ac [0x102ad8d94]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _Py_VectorCallInstrumentation_StackRefSteal+0x2b8 [0x102e30e10]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyEval_EvalFrameDefault+0x13f44 [0x102e47370]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyEval_Vector+0x420 [0x102e30068]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyObject_VectorcallDictTstate+0x1a4 [0x102ad88a0]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyObject_Call_Prepend+0x134 [0x102adb134]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at slot_tp_call+0x124 [0x102c5d2f0]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyObject_Call+0x13c [0x102ada544]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyEval_EvalFrameDefault+0x2b40 [0x102e35f6c]
  Binary file "/Users/thomas.kowalski/Documents/cpython-asan/install/bin/python3.16", at _PyEval_Vector+0x420 [0x102e30068]
  <truncated rest of calls>

Extension modules: msgpack._cmsgpack (total: 1)
zsh: abort      ASAN_OPTIONS=detect_leaks=0 python -m pytest test/test_memoryview.py -k 
```
