### PR TITLE
skip recursion limit test on free-threaded CPython builds

### DIFF
--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import sysconfig
+
 import pytest
 
 from msgpack import (
@@ -153,6 +155,11 @@ def test_auto_max_array_len():
         unpacker.unpack()
 
 
+# Skip on free-threaded CPython builds because this test depends on recursion behavior.
+IS_FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+@pytest.mark.skipif(IS_FREE_THREADED_BUILD, reason="Skipped on free-threaded build")
 def test_nest_limit_1024():
     import sys
 


### PR DESCRIPTION
ja: なぜかわかりませんが、github actionではfree threaded cpythonでrecursion limitを回避できないようなので、テストをスキップすることにします。
en: For some reason, it seems that the recursion limit cannot be avoided in free-threaded CPython on GitHub Actions, so I will skip the test.