### PR TITLE
Bump sys.setrecursionlimit within test_nest_limit_1024

### DIFF
--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -163,7 +163,7 @@ def test_nest_limit_1024():
 
     # Temporarily raise Python's recursion limit so packing 1024 levels succeeds
     old_limit = sys.getrecursionlimit()
-    sys.setrecursionlimit(max(old_limit, 10000))
+    sys.setrecursionlimit(max(old_limit, 30000))
     try:
         packed = packb(d)
         result = unpackb(packed)


### PR DESCRIPTION
Fixes test failures with no-GIL interpreters