### PR TITLE
Wheels CI hangs for MacOS Intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,13 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "windows-11-arm", "macos-latest"]
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+        - windows-latest
+        - windows-11-arm
+        - macos-15-intel
+        - macos-latest
         py: ["3.15", "3.15t", "3.14", "3.14t", "3.13", "3.12", "3.11", "3.10"]
         exclude:
           - os: windows-11-arm

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,13 +11,12 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        # macos-13 is for intel
         include:
         - os: ubuntu-24.04
         - os: ubuntu-24.04-arm
         - os: windows-latest
         - os: windows-11-arm
-        - os: macos-13
+        - os: macos-15-intel
         - os: macos-latest
         - os: ubuntu-24.04
           cibw_archs: riscv64


### PR DESCRIPTION
- Fix wheels generation for MacOS Intel, which is hanging due to gha VM brownout: https://github.com/msgpack/msgpack-python/actions/runs/26874183762/job/79271522595
- Run tests on MacOS Intel and on Ubuntu ARM