### PR TITLE
Fix Timestamp.from_datetime() precision for far-future datetimes

### DIFF
--- a/msgpack/ext.py
+++ b/msgpack/ext.py
@@ -2,6 +2,8 @@ import datetime
 import struct
 from collections import namedtuple
 
+_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+
 
 class ExtType(namedtuple("ExtType", "code data")):
     """ExtType represents ext type in msgpack."""
@@ -156,8 +158,7 @@ class Timestamp:
 
         :rtype: `datetime.datetime`
         """
-        utc = datetime.timezone.utc
-        return datetime.datetime.fromtimestamp(0, utc) + datetime.timedelta(
+        return _EPOCH + datetime.timedelta(
             seconds=self.seconds, microseconds=self.nanoseconds // 1000
         )
 
@@ -167,4 +168,17 @@ class Timestamp:
 
         :rtype: Timestamp
         """
-        return Timestamp(seconds=int(dt.timestamp() // 1), nanoseconds=dt.microsecond * 1000)
+        # Use integer timedelta arithmetic (like the Cython packer) rather than
+        # ``int(dt.timestamp() // 1)``.  ``datetime.timestamp()`` returns a float
+        # that cannot hold microsecond precision for datetimes far from the epoch,
+        # so it may round the whole-second part up while the exact ``microsecond``
+        # is still used for the nanoseconds -- producing a Timestamp one second in
+        # the future (and OverflowError near datetime.max).
+        if dt.tzinfo is None:
+            # Match datetime.timestamp(): a naive datetime is treated as local time.
+            dt = dt.astimezone()
+        delta = dt - _EPOCH
+        return Timestamp(
+            seconds=delta.days * 86400 + delta.seconds,
+            nanoseconds=delta.microseconds * 1000,
+        )

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -111,6 +111,40 @@ def test_timestamp_datetime():
     assert ts_pre_epoch.to_datetime() == pre_epoch
 
 
+def test_from_datetime_far_future_precision():
+    # Regression: Timestamp.from_datetime used the float datetime.timestamp(),
+    # which cannot hold microsecond precision far from the epoch.  It rounded the
+    # whole-second part up by one while still taking the exact microsecond for the
+    # nanoseconds, yielding a Timestamp one second in the future -- and raised
+    # OverflowError near datetime.max.  It must instead match the integer
+    # arithmetic used by the Cython packer.
+    utc = datetime.timezone.utc
+    epoch = datetime.datetime(1970, 1, 1, tzinfo=utc)
+
+    for dt in [
+        datetime.datetime(2515, 1, 1, 0, 0, 0, 999999, tzinfo=utc),
+        datetime.datetime(3000, 1, 1, 0, 0, 0, 999999, tzinfo=utc),
+        datetime.datetime(5000, 6, 15, 12, 30, 45, 123456, tzinfo=utc),
+        # Near datetime.max: previously raised OverflowError.
+        datetime.datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=utc),
+    ]:
+        ts = Timestamp.from_datetime(dt)
+        # Round-trips exactly (was one second in the future).
+        assert ts.to_datetime() == dt
+        # Whole-second part is exact, computed independently of the implementation.
+        assert ts.seconds == (dt - epoch) // datetime.timedelta(seconds=1)
+        assert ts.nanoseconds == dt.microsecond * 1000
+        # The pure-Python path agrees with packing the datetime directly (the
+        # reference path), i.e. no off-by-one-second divergence.
+        assert msgpack.packb(ts) == msgpack.packb(dt, datetime=True)
+
+    # Explicit value: 3000-01-01T00:00:00.999999Z is 32503680000 s after the
+    # epoch; the float path produced 32503680001 (one second in the future).
+    ts = Timestamp.from_datetime(datetime.datetime(3000, 1, 1, 0, 0, 0, 999999, tzinfo=utc))
+    assert ts.seconds == 32503680000
+    assert ts.nanoseconds == 999999000
+
+
 def test_unpack_datetime():
     t = Timestamp(42, 14)
     utc = datetime.timezone.utc


### PR DESCRIPTION
`Timestamp.from_datetime()` computes the whole-second part from the float `datetime.timestamp()`. A float64 cannot hold microsecond precision for datetimes far from the epoch, so `timestamp()` rounds the seconds up while the exact `microsecond` is still used for the nanoseconds. The result is a `Timestamp` one second in the future, and near `datetime.max` it raises `OverflowError`:

```python
>>> import datetime as dt
>>> from msgpack.ext import Timestamp
>>> d = dt.datetime(3000, 1, 1, 0, 0, 0, 999999, tzinfo=dt.timezone.utc)
>>> Timestamp.from_datetime(d).to_datetime()
datetime.datetime(3000, 1, 1, 0, 0, 1, 999999, tzinfo=datetime.timezone.utc)   # +1 second
>>> Timestamp.from_datetime(dt.datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=dt.timezone.utc))
OverflowError: date value out of range
```

The Cython packer already uses integer `timedelta` arithmetic and is correct. This makes the pure-Python `from_datetime()` do the same, so the two paths agree and the round-trip invariant `from_datetime(d).to_datetime() == d` holds for far-future datetimes. Naive datetimes keep their existing local-time interpretation (matching `datetime.timestamp()`).

Follow-up to #662, which fixed the pre-epoch rounding direction in the same method.

Existing tests are unchanged; I added a regression test covering the far-future round-trip, the exact seconds/nanoseconds, agreement with packing the datetime directly, and the former `OverflowError` case. Full suite is green on both the C-extension and pure-Python paths.
