### PR TITLE
Fix typos in test and docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -269,7 +269,7 @@ epub_copyright = "2013, Author"
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -90,10 +90,10 @@ def test_unpacker_tell_read_bytes():
     objects = 1, "abc", "ghi"
     packed = b"\x01\x02\xa3abc\xa3def\xa3ghi"
     raw_data = b"\x02", b"\xa3def", b""
-    lenghts = 1, 4, 999
+    lengths = 1, 4, 999
     positions = 1, 6, 14
     unpacker = Unpacker(BytesIO(packed))
-    for obj, unp, pos, n, raw in zip(objects, unpacker, positions, lenghts, raw_data):
+    for obj, unp, pos, n, raw in zip(objects, unpacker, positions, lengths, raw_data):
         assert obj == unp
         assert pos == unpacker.tell()
         assert unpacker.read_bytes(n) == raw


### PR DESCRIPTION
Fix two typos found by codespell:

- `test/test_unpack.py`: rename variable `lenghts` to `lengths`
- `docs/conf.py`: fix `shat` to `that` in a comment