### PR TITLE
Fix bare except clause in msgpack/fallback.py

### DIFF
--- a/msgpack/fallback.py
+++ b/msgpack/fallback.py
@@ -806,7 +806,7 @@ class Packer:
     def pack(self, obj):
         try:
             self._pack(obj)
-        except:
+        except Exception:
             self._buffer = BytesIO()  # force reset
             raise
         if self._autoreset:


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in the `pack()` method's buffer reset handler.

Bare `except:` catches `BaseException` (including `SystemExit` and `KeyboardInterrupt`), which means pressing Ctrl+C during a pack operation would silently reset the buffer instead of propagating the interrupt. Using `except Exception:` preserves the buffer-reset behavior for actual serialization errors while allowing `KeyboardInterrupt` and `SystemExit` to propagate normally.