### PR TITLE
Validate nanoseconds range when unpacking timestamps in the C extension

### DIFF
--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -282,7 +282,7 @@ static int unpack_timestamp(const char* buf, unsigned int buflen, msgpack_timest
         return -1;
     }
     if (ts->tv_nsec > 999999999) {
-        PyErr_Format(PyExc_ValueError, "nanoseconds must be a non-negative integer less than 999999999.");
+        PyErr_Format(PyExc_ValueError, "nanoseconds must be a non-negative integer not greater than 999999999.");
         return -1;
     }
     return 0;

--- a/msgpack/unpack.h
+++ b/msgpack/unpack.h
@@ -271,16 +271,21 @@ static int unpack_timestamp(const char* buf, unsigned int buflen, msgpack_timest
         uint64_t value =_msgpack_load64(uint64_t, buf);
         ts->tv_nsec = (uint32_t)(value >> 34);
         ts->tv_sec = value & 0x00000003ffffffffLL;
-        return 0;
+        break;
     }
     case 12:
         ts->tv_nsec = _msgpack_load32(uint32_t, buf);
         ts->tv_sec = _msgpack_load64(int64_t, buf + 4);
-        return 0;
+        break;
     default:
         PyErr_Format(PyExc_ValueError, "invalid timestamp data (length %u)", buflen);
         return -1;
     }
+    if (ts->tv_nsec > 999999999) {
+        PyErr_Format(PyExc_ValueError, "nanoseconds must be a non-negative integer less than 999999999.");
+        return -1;
+    }
+    return 0;
 }
 
 #include "datetime.h"

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -71,6 +71,15 @@ def test_unpack_timestamp():
         msgpack.unpackb(b"\xc7\x05\xff\0\0\0\0\0")  # ext8 (len=5)
 
 
+def test_unpack_timestamp_out_of_range_nanoseconds():
+    # An out-of-range nanoseconds field must be rejected in every timestamp=
+    # mode (spec: nanoseconds must not exceed 999999999), not only the default.
+    for data in (b"\xd7\xff" + b"\xff" * 8, b"\xc7\x0c\xff" + b"\xff" * 12):
+        for mode in (0, 1, 2, 3):
+            with pytest.raises(ValueError):
+                msgpack.unpackb(data, timestamp=mode)
+
+
 def test_timestamp_from():
     t = Timestamp(42, 14000)
     assert Timestamp.from_unix(42.000014) == t


### PR DESCRIPTION
The C extension's `unpack_timestamp()` decodes the nanoseconds field of a timestamp64/timestamp96 but never range-checks it, so with `timestamp=1|2|3` it silently accepts a malformed value ≥ 1,000,000,000:

```python
>>> import msgpack, struct
>>> b = b"\xd7\xff" + struct.pack("!Q", (10**9 << 34))  # timestamp64, ns = 1e9
>>> msgpack.unpackb(b, timestamp=1)   # C ext, float mode
1.0                                    # accepted, time-shifted ~1s
>>> msgpack.unpackb(b, timestamp=0)   # C ext, default Timestamp mode
ValueError: ...                        # correctly rejected
```

Three signals agree this is a bug, not lenient parsing:

- The wire spec: *"In timestamp 64 and timestamp 96 formats, nanoseconds must not be larger than 999999999."*
- The pure-Python fallback (`Timestamp.__init__`) already rejects it in every mode.
- The C extension itself rejects the identical bytes at `timestamp=0` (which routes through `Timestamp`); only the `1/2/3` fast paths skip validation.

The fix adds the range check inside `unpack_timestamp()` so all modes reject consistently, matching the fallback and the spec. Valid nanoseconds (≤ 999999999) are unaffected. Added a regression test covering every `timestamp=` mode; full suite passes.

---

Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account — it found the C-vs-fallback divergence, reproduced it, wrote the fix and the test, and wrote this description. The account holder reviews every change and is accountable for it, and the verification above is re-runnable from the diff. Happy to close it if it isn't the kind of contribution you want.
