### PR TITLE
Check exported buffers after the default callback returns

### DIFF
--- a/msgpack/_packer.pyx
+++ b/msgpack/_packer.pyx
@@ -264,6 +264,9 @@ cdef class Packer:
             ret = self._pack_inner(o, 1, nest_limit)
             if ret == -2:
                 o = self._default(o)
+                # The callback may have exported the internal buffer.
+                # Packing on would reallocate it and invalidate the export.
+                self._check_exports()
             else:
                 return ret
         return self._pack_inner(o, 0, nest_limit)

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -47,3 +47,25 @@ def test_packer_getbuffer():
         buffer.release()
         packer.pack(42)
         assert bytes(packer) == b"\x92*\xa5hello*"
+
+
+def test_packer_getbuffer_in_default():
+    # The default callback can export the internal buffer.
+    # The packer must refuse to pack on, because packing on reallocates
+    # the buffer and leaves the export pointing at freed memory.
+    exported = []
+
+    class Unsupported:
+        pass
+
+    def default(obj):
+        exported.append(packer.getbuffer())
+        return b"A" * (2 * 1024 * 1024)
+
+    packer = Packer(default=default, autoreset=False)
+    with raises(BufferError):
+        packer.pack([Unsupported()])
+
+    assert len(exported) == 1
+    assert bytes(exported[0]) == b"\x91"
+    exported[0].release()


### PR DESCRIPTION
`Packer.pack()` calls the `default` callback for an unsupported object. The callback can export the internal buffer with `getbuffer()` or `memoryview(packer)`. The packer then packs the value that the callback returns. `msgpack_pack_write()` in `pack.h` reallocates the buffer when that value does not fit. The export then points at freed memory. A read of the export is a heap use-after-free.

`_check_exports()` already guards the six public entry points of `Packer`. It does not run again after the callback returns. This change calls it right after the callback returns. `Packer.pack()` now raises `BufferError`.

The pure Python packer already raises `BufferError` for the same code, because `BytesIO.write()` refuses to resize a buffer that has an export. This change makes the two implementations agree.

I also considered a guard inside `msgpack_pack_write()`. That needs an export count in the plain C `msgpack_packer` struct. The callback is the only place that runs user code during a pack, so I kept the check at the call site. I am happy to move it if you prefer the lower layer.

The new test is `test/test_buffer.py::test_packer_getbuffer_in_default`. It sits next to the existing `test_packer_getbuffer` test. It passes for both the C extension and the pure Python fallback. It fails on the current code, because the pack succeeds and leaves a dangling export.
