### PR TITLE
Reject a mode change while an object is incomplete

### DIFF
--- a/msgpack/unpack_template.h
+++ b/msgpack/unpack_template.h
@@ -35,6 +35,8 @@ struct unpack_context {
     unsigned int cs;
     unsigned int trail;
     unsigned int top;
+    /* mode that started the object on the stack. See unpack_check_mode(). */
+    bool construct;
     unpack_stack stack[MSGPACK_EMBED_STACK_SIZE];
 };
 
@@ -44,6 +46,7 @@ static inline void unpack_init(unpack_context* ctx)
     ctx->cs = CS_HEADER;
     ctx->trail = 0;
     ctx->top = 0;
+    ctx->construct = true;
     ctx->stack[0].obj = NULL;
 }
 
@@ -386,7 +389,27 @@ _end:
 #undef again_fixed_trail_if_zero
 #undef start_container
 
+/*
+ * skip mode does not build the objects on the stack, so stack[].obj stays
+ * uninitialized. A later construct pass writes an item through that pointer.
+ * The reverse order drops the reference that the construct pass took.
+ * Reject the mode change while an object is still open.
+ */
+static inline int unpack_check_mode(unpack_context *ctx, bool construct)
+{
+    if (ctx->top != 0 && ctx->construct != construct) {
+        PyErr_SetString(PyExc_ValueError,
+                        "cannot switch between unpack and skip while an object is incomplete");
+        return -1;
+    }
+    ctx->construct = construct;
+    return 0;
+}
+
 static int unpack_construct(unpack_context *ctx, const char *data, Py_ssize_t len, Py_ssize_t *off) {
+    if (unpack_check_mode(ctx, true) < 0) {
+        return -1;
+    }
     int ret = unpack_execute(1, ctx, data, len, off);
     if (ret == -1) {
         unpack_clear(ctx);
@@ -394,6 +417,9 @@ static int unpack_construct(unpack_context *ctx, const char *data, Py_ssize_t le
     return ret;
 }
 static int unpack_skip(unpack_context *ctx, const char *data, Py_ssize_t len, Py_ssize_t *off) {
+    if (unpack_check_mode(ctx, false) < 0) {
+        return -1;
+    }
     int ret = unpack_execute(0, ctx, data, len, off);
     if (ret == -1) {
         unpack_clear(ctx);

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import io
 
-from pytest import raises
+from pytest import mark, raises
 
 from msgpack import BufferFull, Unpacker, pack, packb
 from msgpack.exceptions import OutOfData
@@ -146,3 +146,30 @@ def test_unpack_tell():
         m2 = next(unpacker)
         assert m == m2
         assert o == unpacker.tell()
+
+
+@mark.skipif(
+    Unpacker.__module__ == "msgpack.fallback",
+    reason="only the C extension keeps parser state between calls",
+)
+def test_mode_switch_while_incomplete():
+    # skip() does not build the objects that unpack() needs, so the parser
+    # state of one mode is not valid for the other. The unpacker must reject
+    # the change instead of a crash. The original mode still finishes.
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.skip()
+    unpacker.feed(b"\x00")
+    with raises(ValueError):
+        unpacker.unpack()
+    assert unpacker.skip() is None
+
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.unpack()
+    unpacker.feed(b"\x00")
+    with raises(ValueError):
+        unpacker.skip()
+    assert unpacker.unpack() == [0]


### PR DESCRIPTION
`Unpacker` keeps its parser state between calls, so an incomplete object stays on the stack. `unpack_execute()` runs in two modes. Construct mode builds the objects. Skip mode does not.

`construct_cb()` short circuits in skip mode, so `start_container()` never sets `stack[top].obj`. That pointer stays uninitialized after an incomplete `skip()`. A later `unpack()` reaches the `_array_item` call and writes an item through it. The process crashes.

The reverse order is also wrong. An incomplete `unpack()` builds a container and holds a reference to it. A later `skip()` overwrites `stack[0].obj` at `_finish` and drops that reference.

`unpack_context` recorded nothing about the mode, and neither `unpack_construct()` nor `unpack_skip()` looked at `ctx->top`. This change adds a `construct` field to `unpack_context`. Both entry points now compare it against the requested mode. They raise `ValueError` when an object is still open and the mode differs.

The check runs before `unpack_execute()`, so the parser state stays intact. The caller can still finish the object with the original method. The tests cover that.

I used `ValueError` to match `unpack_container_header.h`, which raises `ValueError` for input the parser rejects. `RuntimeError` in these files marks internal state corruption, so it did not fit.

The new test is `test/test_sequnpack.py::test_mode_switch_while_incomplete`. It covers both orders. The pure Python `Unpacker` restarts from a checkpoint and keeps no partial state, so it does not have this failure and does not need the guard. The test carries the same `skipif` marker that the other C extension tests use.
