### PR TITLE
Refuse to resume a partial array/map with the other of skip()/unpack()

### DIFF
--- a/msgpack/_unpacker.pyx
+++ b/msgpack/_unpacker.pyx
@@ -44,6 +44,7 @@ cdef extern from "unpack.h":
         msgpack_user user
         PyObject* obj
         Py_ssize_t count
+        unsigned int top
 
     ctypedef int (*execute_fn)(unpack_context* ctx, const char* data,
                                Py_ssize_t len, Py_ssize_t* off) except -1
@@ -320,6 +321,10 @@ cdef class Unpacker:
     cdef Py_ssize_t max_buffer_size
     cdef uint64_t stream_offset
     cdef bint _unpacking
+    # Which of unpack_construct/unpack_skip left an array or map open on
+    # the last call, so a later call can refuse to resume it with the
+    # other one instead of touching stack entries it never populated.
+    cdef execute_fn _resume_execute
 
     def __dealloc__(self):
         unpack_clear(&self.ctx)
@@ -473,6 +478,14 @@ cdef class Unpacker:
         cdef object obj
         cdef Py_ssize_t prev_head
 
+        if (self.ctx.top != 0 and self._resume_execute != NULL
+                and self._resume_execute != execute):
+            raise ValueError(
+                "unpack() and skip() cannot be mixed while an array or "
+                "map is still incomplete; finish it with the same method "
+                "that started it"
+            )
+
         self._unpacking = True
         try:
             while 1:
@@ -486,8 +499,10 @@ cdef class Unpacker:
                 if ret == 1:
                     obj = unpack_data(&self.ctx)
                     unpack_init(&self.ctx)
+                    self._resume_execute = NULL
                     return obj
                 if ret == 0:
+                    self._resume_execute = execute
                     if self.file_like is not None:
                         self.read_from_file()
                         continue
@@ -497,6 +512,7 @@ cdef class Unpacker:
                         raise OutOfData("No more data to unpack.")
 
                 unpack_clear(&self.ctx)
+                self._resume_execute = NULL
                 if ret == -2:
                     raise FormatError
                 elif ret == -3:

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -63,6 +63,48 @@ def test_foobar_skip():
         unpacker.unpack()
 
 
+def test_skip_then_unpack_across_incomplete_container():
+    # skip() opens the array's stack frame without ever populating its
+    # object slot (it has nothing to build), so resuming with unpack()
+    # used to reuse that slot as if it held a real list and crash. See
+    # GH #734.
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.skip()
+    unpacker.feed(b"\x00")
+    with raises(ValueError):
+        unpacker.unpack()
+
+
+def test_unpack_then_skip_across_incomplete_container():
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.unpack()
+    unpacker.feed(b"\x00")
+    with raises(ValueError):
+        unpacker.skip()
+
+
+def test_skip_then_skip_across_incomplete_container_still_works():
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.skip()
+    unpacker.feed(b"\x00")
+    assert unpacker.skip() is None
+
+
+def test_unpack_then_unpack_across_incomplete_container_still_works():
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.unpack()
+    unpacker.feed(b"\x00")
+    assert unpacker.unpack() == [0]
+
+
 def test_maxbuffersize():
     with raises(ValueError):
         Unpacker(read_size=5, max_buffer_size=3)

--- a/test/test_sequnpack.py
+++ b/test/test_sequnpack.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import io
 
+import pytest
 from pytest import raises
 
 from msgpack import BufferFull, Unpacker, pack, packb
@@ -63,6 +64,10 @@ def test_foobar_skip():
         unpacker.unpack()
 
 
+@pytest.mark.skipif(
+    Unpacker.__module__ == "msgpack.fallback",
+    reason="only the C extension keeps a stack frame across an incomplete read",
+)
 def test_skip_then_unpack_across_incomplete_container():
     # skip() opens the array's stack frame without ever populating its
     # object slot (it has nothing to build), so resuming with unpack()
@@ -77,6 +82,10 @@ def test_skip_then_unpack_across_incomplete_container():
         unpacker.unpack()
 
 
+@pytest.mark.skipif(
+    Unpacker.__module__ == "msgpack.fallback",
+    reason="only the C extension keeps a stack frame across an incomplete read",
+)
 def test_unpack_then_skip_across_incomplete_container():
     unpacker = Unpacker()
     unpacker.feed(b"\x91")
@@ -103,6 +112,37 @@ def test_unpack_then_unpack_across_incomplete_container_still_works():
         unpacker.unpack()
     unpacker.feed(b"\x00")
     assert unpacker.unpack() == [0]
+
+
+@pytest.mark.skipif(
+    Unpacker.__module__ != "msgpack.fallback",
+    reason="the C extension is the one that needs to reject this mix, see the tests above",
+)
+def test_fallback_skip_then_unpack_across_incomplete_container_still_works():
+    # The fallback never keeps a stack frame across an OutOfData; an
+    # incomplete read rolls the buffer position back to where the call
+    # started, so the next call just reparses the array header from
+    # scratch regardless of which method it uses. No corruption risk here,
+    # so unlike the C extension it doesn't need to reject the mix.
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.skip()
+    unpacker.feed(b"\x00")
+    assert unpacker.unpack() == [0]
+
+
+@pytest.mark.skipif(
+    Unpacker.__module__ != "msgpack.fallback",
+    reason="the C extension is the one that needs to reject this mix, see the tests above",
+)
+def test_fallback_unpack_then_skip_across_incomplete_container_still_works():
+    unpacker = Unpacker()
+    unpacker.feed(b"\x91")
+    with raises(OutOfData):
+        unpacker.unpack()
+    unpacker.feed(b"\x00")
+    assert unpacker.skip() is None
 
 
 def test_maxbuffersize():


### PR DESCRIPTION
Closes #734.

\`skip()\` and \`unpack()\` both run through \`Unpacker._unpack()\`, sharing the same underlying context and container stack. The difference between them comes from a single \`construct\` flag threaded through the C state machine: when it's false (skip mode), the per-value callbacks are simply never invoked, so nothing gets written into a container frame's object slot, since skip mode has no Python object to put there in the first place.

That's fine as long as the same mode finishes what it started. But if \`skip()\` opens an array or map and the buffer runs out before it's done, \`unpack()\` can be called next to resume the very same in-progress parse. \`unpack()\` has no idea the frame it's about to append into was left empty by skip mode, so it treats that slot as if it already held a real list or dict and corrupts memory trying to write into it. Locally this reproduces as a straightforward segfault:

\`\`\`python
import msgpack

unpacker = msgpack.Unpacker()
unpacker.feed(b"\x91")
try:
    unpacker.skip()
except msgpack.OutOfData:
    pass
unpacker.feed(b"\x00")
unpacker.unpack()  # segfault
\`\`\`

The fix tracks which of \`unpack_construct\`/\`unpack_skip\` last made progress on a container that's still open (\`ctx.top != 0\`), and raises a \`ValueError\` if the next call tries to continue it with the other one. Resuming with the same method that started the parse is unaffected and keeps working exactly as before, including \`read_array_header()\`/\`read_map_header()\`-driven iteration, which never leaves \`ctx.top\` nonzero across separate top-level \`unpack()\` calls.

Added four tests covering both crash directions and confirming both same-method resumes still work. Ran the full suite (142 tests) plus ruff, all clean.